### PR TITLE
style: 공통 컴포넌트 (스킬 뱃지, 포지션 버튼, 상태 뱃지) 퍼블리싱

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@supabase/supabase-js": "^2.47.16",
     "axios": "^1.7.9",
     "pinia": "^2.3.0",
+    "tailwind-merge": "^2.6.0",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       pinia:
         specifier: ^2.3.0
         version: 2.3.0(vue@3.5.13)
+      tailwind-merge:
+        specifier: ^2.6.0
+        version: 2.6.0
       vue:
         specifier: ^3.5.13
         version: 3.5.13
@@ -1527,6 +1530,9 @@ packages:
 
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
+
+  tailwind-merge@2.6.0:
+    resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
 
   tailwindcss@3.4.17:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
@@ -3183,6 +3189,8 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-tags@1.0.0: {}
+
+  tailwind-merge@2.6.0: {}
 
   tailwindcss@3.4.17:
     dependencies:

--- a/src/components/PositionSelectButton.vue
+++ b/src/components/PositionSelectButton.vue
@@ -1,0 +1,42 @@
+<script setup>
+import { twMerge } from 'tailwind-merge';
+import { computed } from 'vue';
+
+const props = defineProps({
+  size: {
+    type: String,
+    required: true,
+    validator: (value) => ['large', 'small'].includes(value),
+  },
+  isSelected: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['click']);
+
+const sizeClass = {
+  large: 'py-2.5 px-8',
+  small: 'py-[6px] px-6',
+};
+
+const activeClass = {
+  selected: 'bg-secondary-2 text-primary-3 border-primary-3',
+  nonSelected: 'bg-white text-gray-80 border-transparent',
+};
+
+const styleClass = computed(() =>
+  twMerge(
+    'border input-shadow w-full rounded-[10px] body-large-m',
+    sizeClass[props.size],
+    props.isSelected ? activeClass.selected : activeClass.nonSelected,
+  ),
+);
+</script>
+<template>
+  <button type="button" :class="styleClass" @click="emit('click')">
+    <slot></slot>
+  </button>
+</template>
+<style scoped></style>

--- a/src/components/SkillBadge.vue
+++ b/src/components/SkillBadge.vue
@@ -2,7 +2,7 @@
 <template>
   <span class="w-fit flex items-center gap-1.5 p-1.5 pr-2.5 rounded-full border bg-white">
     <slot name="icon" :className="'w-6 h-6'"></slot>
-    <slot class="text-gray-80"></slot>
+    <slot class="text-gray-80 caption-r"></slot>
   </span>
 </template>
 <style scoped></style>

--- a/src/components/SkillBadge.vue
+++ b/src/components/SkillBadge.vue
@@ -1,0 +1,8 @@
+<script setup></script>
+<template>
+  <span class="w-fit flex items-center gap-1.5 p-1.5 pr-2.5 rounded-full border bg-white">
+    <slot name="icon" :className="'w-6 h-6'"></slot>
+    <slot class="text-gray-80"></slot>
+  </span>
+</template>
+<style scoped></style>

--- a/src/components/SkillSelectButton.vue
+++ b/src/components/SkillSelectButton.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { twMerge } from 'tailwind-merge';
+import { computed, defineProps, defineEmits } from 'vue';
+
+const props = defineProps({
+  isSelected: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['click']);
+
+const activeClass = {
+  selected: 'bg-secondary-2 text-primary-3 border-primary-3',
+  nonSelected: 'bg-white text-gray-80 border-gray-30',
+};
+
+const styleClass = computed(() =>
+  twMerge(
+    'w-fit flex items-center gap-1.5 p-1.5 pr-2.5 rounded-full border',
+    props.isSelected ? activeClass.selected : activeClass.nonSelected,
+  ),
+);
+</script>
+<template>
+  <button type="button" :class="styleClass" @click="emit('click')">
+    <slot name="icon" :className="'w-6 h-6'"></slot>
+    <slot class="bg-blue-400"></slot>
+  </button>
+</template>
+<style scoped></style>

--- a/src/components/SkillSelectButton.vue
+++ b/src/components/SkillSelectButton.vue
@@ -26,7 +26,7 @@ const styleClass = computed(() =>
 <template>
   <button type="button" :class="styleClass" @click="emit('click')">
     <slot name="icon" :className="'w-6 h-6'"></slot>
-    <slot class="bg-blue-400"></slot>
+    <slot class="text-gray-80 caption-r"></slot>
   </button>
 </template>
 <style scoped></style>

--- a/src/components/StatusBadge.vue
+++ b/src/components/StatusBadge.vue
@@ -17,12 +17,12 @@ const statusColor = {
   done: 'bg-gray-5 text-gray-50 border-gray-50',
 };
 
-const badgeClass = computed(() =>
+const styleClass = computed(() =>
   twMerge('caption-b py-1 border rounded-full px-2.5 justify-center', statusColor[props.status]),
 );
 </script>
 <template>
-  <span :class="badgeClass">
+  <span :class="styleClass">
     <slot></slot>
   </span>
 </template>

--- a/src/components/StatusBadge.vue
+++ b/src/components/StatusBadge.vue
@@ -1,0 +1,28 @@
+<script setup>
+import { computed, defineProps } from 'vue';
+import { twMerge } from 'tailwind-merge';
+
+const props = defineProps({
+  status: {
+    type: String,
+    required: true,
+  },
+});
+
+const statusColor = {
+  success: 'bg-[#F2FFF3] text-[#4AB556] border-[#4AB556]',
+  warning: 'bg-[#FFFAEE] text-[#FFB908] border-[#FFB908]',
+  danger: 'bg-[#FFE9E9] text-[#FF4242] border-[#FF4242]',
+  done: 'bg-gray-5 text-gray-50 border-gray-50',
+};
+
+const badgeClass = computed(() =>
+  twMerge('caption-b py-1 border rounded-full px-2.5 justify-center', statusColor[props.status]),
+);
+</script>
+<template>
+  <span :class="badgeClass">
+    <slot></slot>
+  </span>
+</template>
+<style scoped></style>

--- a/src/components/StatusBadge.vue
+++ b/src/components/StatusBadge.vue
@@ -6,6 +6,7 @@ const props = defineProps({
   status: {
     type: String,
     required: true,
+    validator: (value) => ['success', 'warning', 'danger', 'done'].includes(value),
   },
 });
 


### PR DESCRIPTION
## 🪄 변경 사항
- resolved #22 

### 상태 뱃지 (StatusBadge)
  - 각 색상이 흔하게 의미하는 것들로 status 이름을 지정했습니다. props로 적절한 status를 작성해 사용하시면 됩니다.

### 포지션 선택 버튼 (PositionSelectButton)
  - large와 small 2가지의 사이즈를 반영했습니다.

### 스킬 뱃지 (SkillBadge) 와 스킬 선택 버튼 (SkillSelectButton)
  - 상태 뱃지와 포지션 선택 버튼과 각각 유사하게 동작합니다.
  - 스킬 관련 컴포넌트의 경우, 이미지로 넘어오는 스킬 이미지의 크기 조정을 위해 슬롯으로 className을 받아 사용하셔야 합니다.
```
<SkillBadge>
  <template #icon="{ className }">
    <img ... :class="className" />
    // 혹은
    <svg :class="className"></svg>
  </template>
</SkillBadge>
```

## 💡 반영 브랜치
- style-badge-#22

## 🖼️ 결과 화면 (생략 가능)

## 💬 리뷰어에게 전할 말
