### PR TITLE
Style modal tab menu #31

### DIFF
--- a/src/components/BaseModal.vue
+++ b/src/components/BaseModal.vue
@@ -1,23 +1,23 @@
 <template>
   <!-- 흐린 배경 -->
-  <!-- bg-[#333333] -->
-  <div class="bg-gray-80 w-full h-full fixed top-0 left-0 flex justify-center items-center">
+  <div
+    class="w-full h-full fixed top-0 left-0 flex justify-center items-center"
+    style="background-color: rgba(0, 0, 0, 0.5)"
+  >
     <!-- 모달창 (opacity 적용 안됨) -->
     <div
-      class="py-8 px-12 w-[330px] max-w-[330px] flex flex-col items-start gap-[10px] absolute top-[50%] left-[50%] rounded-[20px] transform: translate-x-[-50%] translate-y-[-50%] bg-secondary-2"
+      class="py-8 px-12 w-[330px] max-w-[330px] flex flex-col items-start gap-[10px] absolute top-1/2 left-1/2 rounded-[20px] transform: -translate-x-1/2 -translate-y-1/2 bg-secondary-2"
     >
-      <div class="flex flex-col items-center gap-[16px] self-stretch">
+      <div class="flex flex-col items-center gap-4 self-stretch">
         <p class="h4-b text-gray-70">
           <slot></slot>
         </p>
-        <div class="flex gap-[16px] w-full mt-[16px]">
-          <button
-            class="body-r bg-white text-gray-70 modal-button-shadow p-2 rounded-[8px] flex-grow"
-          >
+        <div class="flex gap-4 w-full mt-4">
+          <button class="body-r bg-white text-gray-70 modal-button-shadow p-2 rounded-lg flex-grow">
             돌아가기
           </button>
           <button
-            class="body-r bg-[#364861] modal-button-shadow text-white p-2 rounded-[8px] flex-grow"
+            class="body-r bg-primary-1 modal-button-shadow text-white p-2 rounded-lg flex-grow opacity-80"
           >
             완료하기
           </button>
@@ -27,9 +27,4 @@
   </div>
 </template>
 
-<style scoped>
-/* 흐린 배경에만 opacity 적용 */
-.bg-gray-100 {
-  background-color: rgba(169, 169, 169, 0.7); /* opacity 적용된 배경 */
-}
-</style>
+<style scoped></style>

--- a/src/components/BaseModal.vue
+++ b/src/components/BaseModal.vue
@@ -1,6 +1,7 @@
 <template>
   <!-- 흐린 배경 -->
-  <div class="bg-gray-40 w-full h-full fixed top-0 left-0 flex justify-center items-center">
+  <!-- bg-[#333333] -->
+  <div class="bg-gray-80 w-full h-full fixed top-0 left-0 flex justify-center items-center">
     <!-- 모달창 (opacity 적용 안됨) -->
     <div
       class="py-8 px-12 w-[330px] max-w-[330px] flex flex-col items-start gap-[10px] absolute top-[50%] left-[50%] rounded-[20px] transform: translate-x-[-50%] translate-y-[-50%] bg-secondary-2"
@@ -10,7 +11,9 @@
           <slot></slot>
         </p>
         <div class="flex gap-[16px] w-full mt-[16px]">
-          <button class="body-r text-gray-70 modal-button-shadow p-2 rounded-[8px] flex-grow">
+          <button
+            class="body-r bg-white text-gray-70 modal-button-shadow p-2 rounded-[8px] flex-grow"
+          >
             돌아가기
           </button>
           <button

--- a/src/components/BaseModal.vue
+++ b/src/components/BaseModal.vue
@@ -1,0 +1,32 @@
+<template>
+  <!-- 흐린 배경 -->
+  <div class="bg-gray-40 w-full h-full fixed top-0 left-0 flex justify-center items-center">
+    <!-- 모달창 (opacity 적용 안됨) -->
+    <div
+      class="py-8 px-12 w-[330px] max-w-[330px] flex flex-col items-start gap-[10px] absolute top-[50%] left-[50%] rounded-[20px] transform: translate-x-[-50%] translate-y-[-50%] bg-secondary-2"
+    >
+      <div class="flex flex-col items-center gap-[16px] self-stretch">
+        <p class="h4-b text-gray-70">
+          <slot></slot>
+        </p>
+        <div class="flex gap-[16px] w-full mt-[16px]">
+          <button class="body-r text-gray-70 modal-button-shadow p-2 rounded-[8px] flex-grow">
+            돌아가기
+          </button>
+          <button
+            class="body-r bg-[#364861] modal-button-shadow text-white p-2 rounded-[8px] flex-grow"
+          >
+            완료하기
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* 흐린 배경에만 opacity 적용 */
+.bg-gray-100 {
+  background-color: rgba(169, 169, 169, 0.7); /* opacity 적용된 배경 */
+}
+</style>

--- a/src/components/TabMenu.vue
+++ b/src/components/TabMenu.vue
@@ -4,15 +4,22 @@ const props = defineProps({
     type: Array,
     required: true,
   },
+  activeIndex: {
+    type: Number,
+    required: true,
+  },
 });
 </script>
 <template>
-  <div
-    class="w-full flex flex-col justify-center items-center gap-[10px] h-[50px] py-[18px] bg-secondary-1"
-  >
+  <div class="w-full flex flex-col justify-center items-center h-[50px] py-[18px] bg-secondary-1">
     <nav>
       <ul class="body-large-m inline-flex items-center gap-[30px] text-gray-80">
-        <li v-for="(item, index) in props.menuItems" :key="index">
+        <li
+          v-for="(item, index) in props.menuItems"
+          :key="index"
+          class="cursor-pointer"
+          :class="props.activeIndex === index && 'text-primary-2'"
+        >
           {{ item }}
         </li>
       </ul>

--- a/src/components/TabMenu.vue
+++ b/src/components/TabMenu.vue
@@ -1,0 +1,22 @@
+<script setup>
+const props = defineProps({
+  menuItems: {
+    type: Array,
+    required: true,
+  },
+});
+</script>
+<template>
+  <div
+    class="w-full flex flex-col justify-center items-center gap-[10px] h-[50px] py-[18px] bg-secondary-1"
+  >
+    <nav>
+      <ul class="body-large-m inline-flex items-center gap-[30px] text-gray-80">
+        <li v-for="(item, index) in props.menuItems" :key="index">
+          {{ item }}
+        </li>
+      </ul>
+    </nav>
+  </div>
+</template>
+<style scoped></style>

--- a/src/components/TabMenu.vue
+++ b/src/components/TabMenu.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { computed, ref } from 'vue';
+
 const props = defineProps({
   menuItems: {
     type: Array,
@@ -9,6 +11,8 @@ const props = defineProps({
     required: true,
   },
 });
+
+const emit = defineEmits(['update:activeIndex']);
 </script>
 <template>
   <div class="w-full flex flex-col justify-center items-center h-[50px] py-[18px] bg-secondary-1">
@@ -18,6 +22,7 @@ const props = defineProps({
           v-for="(item, index) in props.menuItems"
           :key="index"
           class="cursor-pointer"
+          @click="emit('update:activeIndex', index)"
           :class="props.activeIndex === index && 'text-primary-2'"
         >
           {{ item }}

--- a/src/pages/MyPage.vue
+++ b/src/pages/MyPage.vue
@@ -1,5 +1,15 @@
-<script setup></script>
+<script setup>
+import TabMenu from '@/components/TabMenu.vue';
+import { ref } from 'vue';
+
+const activeIndex = ref(0);
+</script>
 
 <template>
   <div>마이 페이지</div>
+  <TabMenu
+    :menu-items="['내정보', '작성한 글', '찜 목록']"
+    :activeIndex="activeIndex"
+    @update:activeIndex="activeIndex = $event"
+  />
 </template>


### PR DESCRIPTION
## 🪄 변경 사항
resolved #31 

공통 모달 컴포저블 (BaseModal)
- 공통적으로 사용되는 모달창으로, Contents부분에 넣고싶으신 내용을 넣으시면 됩니다.

탭 메뉴 컴포저블 (TabMenu)
마이페이지와 유저페이지의 탭 메뉴에서 사용할 수 있는 컴포저블입니다.
props인 menuItems에 들어갈 탭 메뉴의 리스트를 배열형태로 넣고 보내주시면 됩니다.

```js
<script setup>
import BaseModal from '@/components/BaseModal.vue';
import TabMenu from '@/components/TabMenu.vue';

const myPageArr = ['내 정보', '작성한 모집글', '신청 목록', '찜 목록'];
</script>
<template>
  <h1>메인 페이지</h1>
  <BaseModal>수정을 완료하시겠어요?</BaseModal>
  <TabMenu :menuItems="myPageArr" />
</template>
```

## 💡 반영 브랜치
Style modal tab menu #31 

## 🖼️ 결과 화면 (생략 가능)

## 💬 리뷰어에게 전할 말
