### PR TITLE
🚨 fix : 수파베이스 모든 유저 정보 데이터 불러오기 로직 수정

### DIFF
--- a/src/api/supabase/user.js
+++ b/src/api/supabase/user.js
@@ -324,20 +324,18 @@ const postUpdateUserStacks = async (insertObject, position) => {
 export const getAllUserInfo = async () => {
   const { data: lists, error } = await supabase.from('user_list').select('*');
 
-  const listsArr = lists.map((list) => {
-    return { ...list, link: list.link.split('*') };
-  });
+  const listsArr = lists.map((list) => ({ ...list, link: list.link.split('*') }));
 
   const result = [];
-  listsArr.map(async (list) => {
+  for (const list of listsArr) {
     const { data: positions, error } = await supabase
       .from('user_list_positions')
       .select()
       .eq('profile_id', list.id);
 
     const positionsArr = [];
-    positions.map(async (position) => {
-      const { data: stacks, err } = await supabase //
+    for (const position of positions) {
+      const { data: stacks, err } = await supabase
         .from('user_list_stacks')
         .select()
         .eq('position_id', position.id)
@@ -347,8 +345,8 @@ export const getAllUserInfo = async () => {
         position: position.position,
         stacks: stacks.stacks.split('/'),
       });
-    });
+    }
     result.push({ ...list, positions: positionsArr });
-  });
+  }
   return result;
 };

--- a/src/pages/EditRecruitPostPage/components/FristInfo/BasicInfoSelect.vue
+++ b/src/pages/EditRecruitPostPage/components/FristInfo/BasicInfoSelect.vue
@@ -8,7 +8,7 @@ const props = defineProps({
   },
   items: {
     type: Array,
-    default: [{ id: '', name: '' }],
+    default: [''],
   },
   defaultText: {
     type: String,


### PR DESCRIPTION
## 🪄 변경 사항
- 모든 유저 정보 데이터 불러오기를 했을때 배열이 정상적으로 받아집니다.
- map함수에서 for of문으로 바꿨습니다.
## 💡 반영 브랜치
- origin/fix-supabase-getUserAll-logic-fix- #63
## 🖼️ 결과 화면 (생략 가능)

## 💬 리뷰어에게 전할 말
- 이젠 정상적으로 작동할겁니당 ╰(*°▽°*)╯