### PR TITLE
feat : 댓글 수정/삭제 기능 구현 + 헤더 레이아웃 수정

### DIFF
--- a/src/api/supabase/new_comment.js
+++ b/src/api/supabase/new_comment.js
@@ -6,8 +6,7 @@ export const addPostComment = async (post_id, comment) => {
     p_content: comment,
   });
   if (error) console.error(error);
-  else console.log(data);
-  return data;
+  else return data;
 };
 
 export const getCommentsByPost = async (post_id) => {
@@ -15,25 +14,24 @@ export const getCommentsByPost = async (post_id) => {
     p_post_id: post_id,
   });
   if (error) console.error(error);
-  else {
-    console.log(data);
-    return data;
-  }
+  else return data;
 };
 
-export const deletePostComment = async (comment_id) => {
+export const deletePostComment = async (comment_id, post_id) => {
   const { data, error } = await supabase.rpc('delete_post_comment', {
     p_comment_id: comment_id,
+    p_post_id: post_id,
   });
   if (error) console.error(error);
-  else console.log(data);
+  else return data;
 };
 
-export const updatePostComment = async (post_id, comment) => {
+export const updatePostComment = async (comment_id, comment, post_id) => {
   const { data, error } = await supabase.rpc('update_post_comment', {
-    p_comment_id: post_id,
+    p_comment_id: comment_id,
     p_content: comment,
+    p_post_id: post_id,
   });
   if (error) console.error(error);
-  else console.log(data);
+  else return data;
 };

--- a/src/api/supabase/user.js
+++ b/src/api/supabase/user.js
@@ -364,3 +364,10 @@ export const checkDuplicateNickname = async (nickname) => {
 
   return data; // 중복이면 true, 중복이 아니면 false
 };
+
+// 내 사용자 유저정보 받아오기 테스트(잘 작동됨)
+export const getUserInfoTest = async () => {
+  const { data, error } = await supabase.rpc('get_user_info_test');
+  if (error) console.error(error);
+  else console.log(data);
+};

--- a/src/layout/header/components/LoggedInRight.vue
+++ b/src/layout/header/components/LoggedInRight.vue
@@ -47,7 +47,7 @@ const dropdownList = [
     <li class="flex flex-col justify-center items-end" ref="targetElement">
       <DropdownButton>
         <template #trigger="{ toggleDropdown }">
-          <button @click="toggleDropdown">
+          <button @click="toggleDropdown" class="flex">
             <img :src="default_user_img" alt="유저 기본 이미지 아이콘" class="w-10 rounded-full" />
           </button>
         </template>

--- a/src/pages/RecruitPostDetailPage/components/PostComment.vue
+++ b/src/pages/RecruitPostDetailPage/components/PostComment.vue
@@ -1,0 +1,202 @@
+<script setup>
+import { addPostComment, getCommentsByPost } from '@/api/supabase/new_comment';
+import AppButton from '@/components/AppButton.vue';
+import DropdownMenu from '@/components/DropdownMenu.vue';
+import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
+
+const props = defineProps({
+  error: String,
+  loading: Boolean,
+});
+const emit = defineEmits(['update:error', 'update:loading']);
+
+const localError = computed({
+  get() {
+    return props.error;
+  },
+  set(value) {
+    emit('update:error', value);
+  },
+});
+
+const localLoading = computed({
+  get() {
+    return props.loading;
+  },
+  set(value) {
+    emit('update:loading', value);
+  },
+});
+
+const route = useRoute();
+const postId = ref(route.params.postId);
+const newComment = ref('');
+const comments = reactive([]);
+
+// 댓글 드롭다운 항목 정의
+const dropdownItems = [
+  { label: '댓글 수정하기', action: () => console.log('댓글 수정하기') },
+  { label: '댓글 삭제하기', action: () => console.log('댓글 삭제하기') },
+];
+
+// 댓글 드롭다운 상태 토글 함수
+const toggleDropdown = (comment) => {
+  comment.isDropdownOpen = !comment.isDropdownOpen;
+  // comments.value.forEach((comment) => {
+  //   if (comment.comment_id !== commentId) {
+  //     comment.isDropdownOpen = false;
+  //   }
+  // });
+  // const commentIdx = comments.value.findIndex((c) => c.comment_id === commentId);
+  // if (commentIdx !== -1) {
+  //   comments.value[commentIdx].isDropdownOpen = !comments.value[commentIdx].isDropdownOpen;
+  // }
+  // console.log(comments.value);
+};
+watch(
+  () => comments,
+  (newVal) => {
+    console.log('comments updated:', newVal);
+  },
+  { deep: true },
+);
+
+// 댓글 드롭다운 외부 클릭 감지 함수
+const handleClickOutside = (event) => {
+  const dropdownElements = document.querySelectorAll('.dropdown');
+  const isClickInside = Array.from(dropdownElements).some((el) => el.contains(event.target));
+
+  if (!isClickInside) {
+    comments.map((comment) => ({
+      ...comment,
+      isDropdownOpen: false,
+    }));
+  }
+};
+
+// 댓글 등록 처리
+const handleSubmitComment = async () => {
+  try {
+    if (!newComment.value.trim()) {
+      console.warn('댓글 내용이 비어있습니다.');
+      return;
+    }
+
+    // 댓글 등록 요청
+    const result = await addPostComment(postId.value, newComment.value);
+    console.log('댓글 등록 성공:', result);
+
+    // 댓글 입력란 초기화
+    newComment.value = '';
+
+    // 댓글 추가정보 갱신 로직
+    comments.unshift({ ...result[0], isDropdownOpen: false });
+  } catch (error) {
+    console.error('댓글 등록 실패:', error);
+  }
+};
+
+const formatDate = (dateString) => {
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  return `${year}년 ${month}월 ${day}일`;
+};
+
+onMounted(async () => {
+  try {
+    // postId 유효성 검사
+    if (!postId.value) {
+      throw new Error('유효하지 않은 postId입니다.');
+    }
+
+    // 댓글 데이터 가져오기
+    const commentData = await getCommentsByPost(postId.value);
+
+    //comments 배열 초기화
+    comments.length = 0;
+    // 댓글 데이터 가공
+    commentData.forEach((comment) => {
+      comments.push({ ...comment, isDropdownOpen: false });
+    });
+  } catch (err) {
+    console.error(err);
+    localError.value = '댓글을 불러오는 데 실패했습니다.';
+  } finally {
+    localLoading.value = false;
+  }
+});
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside);
+});
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside);
+});
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- 댓글 작성 영역 -->
+    <div class="flex flex-col items-start gap-2">
+      <div class="flex-1 font-bold">
+        <span class="text-base text-gray-80">{{ comments.length }}개의 댓글</span>
+      </div>
+      <div class="w-full">
+        <textarea
+          v-model="newComment"
+          placeholder="댓글을 입력해주세요"
+          class="text-sm w-full p-2 border rounded-md focus:outline-none focus:ring focus:ring-primary-4"
+          rows="3"
+          maxlength="100"
+        ></textarea>
+        <div class="flex justify-between items-center">
+          <span class="text-xs text-gray-500 mb-10">{{ newComment.length }}/100</span>
+          <div class="flex justify-end mb-8">
+            <AppButton
+              text="댓글 등록"
+              type="primary"
+              class="w-[72px] h-[28px]"
+              @click="handleSubmitComment"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 댓글 목록 -->
+    <div class="space-y-6">
+      <div v-for="(comment, index) in comments" :key="comment.id" class="flex flex-col gap-4">
+        <!-- 유저 프로필 및 닉네임 -->
+        <div class="flex items-center justify-between">
+          <div class="flex">
+            <img
+              :src="comment.commenter_image_path"
+              alt="프로필 이미지"
+              class="w-10 h-10 rounded-full object-cover mr-4 card-shadow"
+            />
+            <div>
+              <p class="font-semibold text-gray-800">{{ comment.commenter_name }}</p>
+              <p class="text-sm text-gray-500">{{ formatDate(comment.created_at) }}</p>
+            </div>
+          </div>
+
+          <button @click="toggleDropdown(comment)">...</button>
+          {{ comment.isDropdownOpen }}
+          <DropdownMenu :is-open="comment.isDropdownOpen" :dropdown-list="dropdownItems" />
+        </div>
+
+        <!-- 댓글 내용 -->
+        <div class="col-start-1 col-span-3">
+          <p class="text-gray-700">{{ comment.content }}</p>
+        </div>
+
+        <!-- 구분선 -->
+        <template v-if="index < comments.length - 1">
+          <hr class="border-t border-gray-300 w-full col-span-3" />
+        </template>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/pages/test_api_page_hw/LoginAndUserTest.vue
+++ b/src/pages/test_api_page_hw/LoginAndUserTest.vue
@@ -14,7 +14,7 @@ import {
   toggleBookmark,
   toggleLike,
 } from '@/api/supabase/like_and_bookmark';
-import { addPostComment } from '@/api/supabase/new_comment';
+
 import {
   addPostComment,
   deletePostComment,
@@ -25,6 +25,7 @@ import { isUserPostAuthor } from '@/api/supabase/post_editor';
 import {
   getAllUserInfo,
   getUserInfo,
+  getUserInfoTest,
   getUserInfoToUserId,
   postUserInfoOnboard,
   putUserInfo,
@@ -124,6 +125,11 @@ onMounted(async () => {
 
   <div>
     <button @click="getUserInfoHandler()">유저 정보 가져오기</button>
+    <p>{{ userInfo }}</p>
+  </div>
+
+  <div>
+    <button @click="getUserInfoTest()">유저 정보 가져오기 함수 시용 버전전</button>
     <p>{{ userInfo }}</p>
   </div>
 


### PR DESCRIPTION
## 🪄 변경 사항
- 댓글 수정/삭제 기능 구현완료
- 게시글 상세페이지 댓글 파트 컴포넌트화
- 헤더 프로필 이미지 영역 스타일 조정
- 수파베이스 현재 사용자 유저데이터 가져오는 로직 rpc함수 사용해서 새로 하나 만들었습니다.(혹시 필요하면 사용!)
## 💡 반영 브랜치
- feat-comment-update/delete-header-css-#89
## 🖼️ 결과 화면 (생략 가능)

## 💬 리뷰어에게 전할 말
- 컴포넌트 분리했는데 충돌 안났으면 좋겠어요 (┬┬﹏┬┬)