### PR TITLE
feat : 알림기능 구현 완료

### DIFF
--- a/src/assets/icons/NotificationSvg.vue
+++ b/src/assets/icons/NotificationSvg.vue
@@ -38,7 +38,7 @@ const dropDownHide = () => {
     </svg>
     <article
       v-if="dropDown"
-      class="absolute bottom-[-10px] rounded-md bg-primary-4 w-[50px] h-4.5 flex items-center justify-center"
+      class="absolute bottom-[-27px] rounded-md bg-primary-4 w-[50px] h-4.5 flex items-center justify-center"
     >
       <span class="caption-r text-white">알림</span>
     </article>

--- a/src/components/notification/AllNotifications.vue
+++ b/src/components/notification/AllNotifications.vue
@@ -1,106 +1,49 @@
 <script setup>
 import { twMerge } from 'tailwind-merge';
 import { notiTypes } from '.';
+import { useNotificationModalStore } from '@/stores/notificaionModal';
+import { storeToRefs } from 'pinia';
+import { useRouter } from 'vue-router';
 
-const dummyNotifications = [
-  {
-    id: 1,
-    user_id: '유저 uuid',
-    post_id: '포스트 id',
-    post_title: '멘토링 관련 프로젝트 팀원 모집합니다.',
-    seen: false,
-    type: 'apply',
-    sender_id: '보내는 사람 user_list id',
-    sender_name: '병알이다요요요',
-  },
-  {
-    id: 2,
-    user_id: '유저 uuid',
-    post_id: '포스트 id',
-    post_title: '함께할 노ㅇ.. 아니 팀원 모집합니다!',
-    seen: false,
-    type: 'comment',
-    sender_id: '보내는 사람 user_list id',
-    sender_name: '노예1',
-  },
-  {
-    id: 3,
-    user_id: '유저 uuid',
-    post_id: '포스트 id',
-    post_title: '멘토링 관련 프로젝트 팀원 모집합니다.',
-    seen: false,
-    type: 'like',
-    sender_id: '보내는 사람 user_list id',
-    sender_name: '따봉도치',
-  },
-  {
-    id: 4,
-    user_id: '유저 uuid',
-    post_id: '포스트 id',
-    post_title: '멘토링 관련 프로젝트 팀원 모집합니다.',
-    seen: true,
-    type: 'apply',
-    sender_id: '보내는 사람 user_list id',
-    sender_name: '프로그래머스 데브코스',
-  },
-  {
-    id: 5,
-    user_id: '유저 uuid',
-    post_id: '포스트 id',
-    post_title: '안녕하세요 오늘도 좋은하루입니다.',
-    seen: false,
-    type: 'comment',
-    sender_id: '보내는 사람 user_list id',
-    sender_name: '인사를 좋아하는 사람',
-  },
-  {
-    id: 6,
-    user_id: '유저 uuid',
-    post_id: '포스트 id',
-    post_title: '백엔드 팀원 한 분 모집합니다.',
-    seen: true,
-    type: 'apply',
-    sender_id: '보내는 사람 user_list id',
-    sender_name: '백엔드 장인',
-  },
-  {
-    id: 7,
-    user_id: '유저 uuid',
-    post_id: '포스트 id',
-    post_title: '모의투자 서비스 프로젝트 팀원 모집합니다.',
-    seen: false,
-    type: 'like',
-    sender_id: '보내는 사람 user_list id',
-    sender_name: '젠슨황',
-  },
-];
+const notificationModalStore = useNotificationModalStore();
+const { notifications } = storeToRefs(notificationModalStore);
+
+// checked 변환 + 상세페이지 라우트 함수
+const router = useRouter();
+const handleCheckNoti = (notification) => {
+  notificationModalStore.updateChecked(notification.id);
+  router.push(`/RecruitPostDetail/${notification.post_id}`);
+  notificationModalStore.closeNotificationModal();
+  notificationModalStore.updateCheckedUI(notification);
+};
 </script>
 
 <template>
   <ul class="w-full h-[424px] flex flex-col gap-2 overflow-y-scroll">
-    <li v-for="notification in dummyNotifications" :key="notification.id">
+    <li v-for="notification in notifications" :key="notification.id">
       <button
         class="w-full flex px-4 py-2 bg-white rounded-lg input-shadow body-m hover:bg-secondary-1"
+        @click="handleCheckNoti(notification)"
       >
         <p
           :class="`${twMerge(
             'max-w-[75px] truncate text-primary-3',
-            notification.seen && 'text-gray-40',
+            notification.checked && 'text-gray-40',
           )}`"
         >
           {{ notification.sender_name }}
         </p>
-        <span :class="`mr-1 ${notification.seen && 'text-gray-40'}`">님이</span>
+        <span :class="`mr-1 ${notification.checked && 'text-gray-40'}`">님이</span>
         <p
           :class="` ${twMerge(
             'max-w-[130px] truncate text-primary-3',
-            notification.seen && 'text-gray-40',
+            notification.checked && 'text-gray-40',
           )}`"
         >
           {{ notification.post_title }}
         </p>
-        <span :class="`mr-1 ${notification.seen && 'text-gray-40'}`">에</span>
-        <span :class="` ${notification.seen && 'text-gray-40'}`">{{
+        <span :class="`mr-1 ${notification.checked && 'text-gray-40'}`">에</span>
+        <span :class="` ${notification.checked && 'text-gray-40'}`">{{
           notiTypes[notification.type]
         }}</span>
       </button>

--- a/src/components/notification/NotificationModal.vue
+++ b/src/components/notification/NotificationModal.vue
@@ -1,15 +1,27 @@
 <script setup>
 import noti_close_icon from '@/assets/icons/noti_close_icon.svg';
 import { twMerge } from 'tailwind-merge';
-import { computed, ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 import AllNotifications from './AllNotifications.vue';
 import UnWatchedNotifications from './UnWatchedNotifications.vue';
 import { useNotificationModalStore } from '@/stores/notificaionModal';
+import { AllMarkAsSeen } from '@/api/supabase/notifications';
+import { storeToRefs } from 'pinia';
 
 const notificationModalStore = useNotificationModalStore();
+const { notifications } = storeToRefs(notificationModalStore);
 
 const toggleState = ref('All');
 const toggleButton = computed(() => twMerge('text-primary-3 border-b-[2px] border-primary-3'));
+
+onMounted(async () => {
+  await AllMarkAsSeen(notifications.value);
+  notificationModalStore.setHasNewNotificationFalse();
+  document.body.style.overflow = 'hidden';
+});
+onUnmounted(() => {
+  document.body.style.overflow = 'inherit';
+});
 </script>
 
 <template>
@@ -49,7 +61,9 @@ const toggleButton = computed(() => twMerge('text-primary-3 border-b-[2px] borde
               </button>
             </li>
           </ul>
-          <button class="caption-m">모두 읽음</button>
+          <button class="caption-m" @click="notificationModalStore.updateCheckAll()">
+            모두 확인
+          </button>
         </div>
         <!-- 컨텐츠 하단(알림) -->
         <AllNotifications v-if="toggleState === 'All'" />

--- a/src/components/notification/UnWatchedNotifications.vue
+++ b/src/components/notification/UnWatchedNotifications.vue
@@ -1,87 +1,55 @@
 <script setup>
 import { twMerge } from 'tailwind-merge';
-import { computed } from 'vue';
+import { onBeforeMount, ref } from 'vue';
 import { notiTypes } from '.';
+import { useNotificationModalStore } from '@/stores/notificaionModal';
+import { storeToRefs } from 'pinia';
+import { useRouter } from 'vue-router';
 
-const dummyNotifications = [
-  {
-    id: 1,
-    user_id: '유저 uuid',
-    post_id: '포스트 id',
-    post_title: '멘토링 관련 프로젝트 팀원 모집합니다.',
-    seen: false,
-    type: 'apply',
-    sender_id: '보내는 사람 user_list id',
-    sender_name: '병알이다요요요',
-  },
-  {
-    id: 2,
-    user_id: '유저 uuid',
-    post_id: '포스트 id',
-    post_title: '함께할 노ㅇ.. 아니 팀원 모집합니다!',
-    seen: false,
-    type: 'comment',
-    sender_id: '보내는 사람 user_list id',
-    sender_name: '노예1',
-  },
-  {
-    id: 3,
-    user_id: '유저 uuid',
-    post_id: '포스트 id',
-    post_title: '멘토링 관련 프로젝트 팀원 모집합니다.',
-    seen: false,
-    type: 'like',
-    sender_id: '보내는 사람 user_list id',
-    sender_name: '따봉도치',
-  },
-  {
-    id: 5,
-    user_id: '유저 uuid',
-    post_id: '포스트 id',
-    post_title: '안녕하세요 오늘도 좋은하루입니다.',
-    seen: false,
-    type: 'comment',
-    sender_id: '보내는 사람 user_list id',
-    sender_name: '인사를 좋아하는 사람',
-  },
-  {
-    id: 7,
-    user_id: '유저 uuid',
-    post_id: '포스트 id',
-    post_title: '모의투자 서비스 프로젝트 팀원 모집합니다.',
-    seen: false,
-    type: 'like',
-    sender_id: '보내는 사람 user_list id',
-    sender_name: '젠슨황',
-  },
-];
+const notificationModalStore = useNotificationModalStore();
+const { notifications } = storeToRefs(notificationModalStore);
+const filteredNotifications = ref([]);
+onBeforeMount(() => {
+  const res = notifications.value.filter((noti) => !noti.checked);
+  filteredNotifications.value = res;
+});
+
+// checked 변환 + 상세페이지 라우트 함수
+const router = useRouter();
+const handleCheckNoti = (notification) => {
+  notificationModalStore.updateChecked(notification.id);
+  router.push(`/RecruitPostDetail/${notification.post_id}`);
+  notificationModalStore.closeNotificationModal();
+  notificationModalStore.updateCheckedUI(notification);
+};
 </script>
 
 <template>
   <ul class="w-full h-[424px] flex flex-col gap-2 overflow-y-scroll">
-    <li v-for="notification in dummyNotifications" :key="notification.id">
+    <li v-for="notification in filteredNotifications" :key="notification.id">
       <button
         class="w-full flex px-4 py-2 bg-white rounded-lg input-shadow body-m hover:bg-secondary-1"
+        @click="handleCheckNoti(notification)"
       >
         <p
           :class="`${twMerge(
             'max-w-[75px] truncate text-primary-3',
-            notification.seen && 'text-gray-40',
+            notification.checked && 'text-gray-40',
           )}`"
         >
           {{ notification.sender_name }}
         </p>
-        <span :class="`mr-1 ${notification.seen && 'text-gray-40'}`">님이</span>
+        <span :class="`mr-1 ${notification.checked && 'text-gray-40'}`">님이</span>
         <p
           :class="` ${twMerge(
             'max-w-[130px] truncate text-primary-3',
-            notification.seen && 'text-gray-40',
+            notification.checked && 'text-gray-40',
           )}`"
         >
           {{ notification.post_title }}
         </p>
-        <span :class="`mr-1 ${notification.seen && 'text-gray-40'}`">에</span>
-        <span :class="` ${notification.seen && 'text-gray-40'}`">{{
+        <span :class="`mr-1 ${notification.checked && 'text-gray-40'}`">에</span>
+        <span :class="` ${notification.checked && 'text-gray-40'}`">{{
           notiTypes[notification.type]
         }}</span>
       </button>

--- a/src/pages/RecruitPostDetailPage/components/PostComment.vue
+++ b/src/pages/RecruitPostDetailPage/components/PostComment.vue
@@ -113,7 +113,8 @@ const toggleDropdown = (comment) => {
 const dropDownRef = ref(null);
 // 댓글 드롭다운 외부 클릭 감지 함수
 const handleClickOutside = (event) => {
-  const isClickInside = Array.from(dropDownRef.value).some((el) => el.contains(event.target));
+  const isClickInside =
+    dropDownRef.value && Array.from(dropDownRef.value).some((el) => el.contains(event.target));
 
   if (!isClickInside) {
     comments.forEach((comment) => {

--- a/src/stores/notificaionModal.js
+++ b/src/stores/notificaionModal.js
@@ -1,3 +1,4 @@
+import { AllMarkAsChecked, getNotifications, markAsChecked } from '@/api/supabase/notifications';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 
@@ -10,9 +11,68 @@ export const useNotificationModalStore = defineStore('notificationModal', () => 
     isNotificationModalOpen.value = false;
   };
 
+  // 알림 목록
+  const notifications = ref([]);
+
+  // 새 알림이 왔는지 여부(추후 헤더 레이아웃 이동)
+  const hasNewNotification = ref(false);
+
+  // 새 알림 상태 true/false로 전환
+  const setHasNewNotificationTrue = () => {
+    hasNewNotification.value = true;
+  };
+  const setHasNewNotificationFalse = () => {
+    hasNewNotification.value = false;
+  };
+
+  // 읽음처리(checked) 함수
+  const updateChecked = async (id) => {
+    const res = await markAsChecked(id);
+    console.log(res);
+  };
+
+  // 읽음처리(checked) UI 업데이트 함수
+  const updateCheckedUI = (target) => {
+    const updatedNoti = notifications.value.map((noti) =>
+      noti.id === target.id ? { ...noti, checked: true } : noti,
+    );
+    notifications.value = updatedNoti;
+  };
+
+  // 모두 읽음처리(checked) 함수
+  const updateCheckAll = () => {
+    AllMarkAsChecked(notifications.value);
+    const allChecked = notifications.value.map((notification) =>
+      !notification.checked ? { ...notification, checked: true } : notification,
+    );
+    notifications.value = allChecked;
+  };
+
+  // 실시간 알림 추가
+  const addNotifications = (updatedData) => {
+    notifications.value.unshift(updatedData);
+  };
+
+  // 로그인한 사용자의 알림 목록 가져오기
+  const fetchNotifications = async () => {
+    notifications.value = await getNotifications();
+    console.log('결과', notifications.value);
+    // 알림 테이블 구독
+    // subscribeToNotifications(notifications.value, hasNewNotification.value);
+  };
+
   return {
     isNotificationModalOpen,
     openNotificationModal,
     closeNotificationModal,
+    notifications,
+    hasNewNotification,
+    fetchNotifications,
+    setHasNewNotificationTrue,
+    setHasNewNotificationFalse,
+    addNotifications,
+    updateChecked,
+    updateCheckedUI,
+    updateCheckAll,
   };
 });


### PR DESCRIPTION
## 🪄 변경 사항
- 알림기능 모두 구현 완료(좋아요, 신청, 댓글 모두 완료)
- 좋아요, 댓글, 신청시 실시간으로 게시글 작성자에게 알림이 가도록 설정
- 알림을 클릭하면 확인된 알림으로 바뀌고 해당 글 상세 페이지로 이동
## 💡 반영 브랜치
- feat-notification-#94
## 🖼️ 결과 화면 (생략 가능)
![image](https://github.com/user-attachments/assets/31b4c96a-04e9-4dad-aeb7-601971138e0f)
![image](https://github.com/user-attachments/assets/5d531159-5d33-4e8a-b840-67a2d343a4fa)
![image](https://github.com/user-attachments/assets/53bb7d6d-050d-4ad5-9840-d73b5b6c2a13)

## 💬 리뷰어에게 전할 말
- 현우님 고생 많으셨습니다 (//ω＼＼)b