### PR TITLE
feat: 마이페이지 수정 토스트 메시지 적용

### DIFF
--- a/src/components/UserProfileModal.vue
+++ b/src/components/UserProfileModal.vue
@@ -46,10 +46,9 @@ const handleUserPageClick = () => {
             class="w-[120px] h-[120px] mb-[18px] rounded-full overflow-hidden user-Profile-img-shadow"
           >
             <img
-              class="w-full h-full object-cover rounded-full"
+              class="object-cover w-full h-full rounded-full"
               :src="userInfo.profile_img_path || DEFAULT_PROFILE_IMAGE_URL"
-              :alt="`${userInfo.userName}의 프로필
-            사진`"
+              :alt="`${userInfo.userName}의 프로필 사진`"
             />
           </div>
           <span class="mb-3 h2-b text-gray-80">{{ userInfo.name }}</span>

--- a/src/layout/header/components/LoggedInRight.vue
+++ b/src/layout/header/components/LoggedInRight.vue
@@ -75,8 +75,11 @@ onUnmounted(() => {
     <li class="flex flex-col justify-center items-end" ref="targetElement">
       <DropdownButton>
         <template #trigger="{ toggleDropdown }">
-          <button @click="toggleDropdown" class="flex">
-            <img :src="default_user_img" alt="유저 기본 이미지 아이콘" class="w-10 rounded-full" />
+          <button
+            @click="toggleDropdown"
+            class="flex w-10 overflow-hidden rounded-full user-Profile-img-shadow"
+          >
+            <img :src="default_user_img" alt="유저 기본 이미지 아이콘" />
           </button>
         </template>
         <template #menu="{ isOpen, closeDropdown }">

--- a/src/pages/EditProfilePage/EditProfilePage.vue
+++ b/src/pages/EditProfilePage/EditProfilePage.vue
@@ -10,6 +10,7 @@ import { useProfileStore } from '@/stores/profile';
 import { getUserInfo, putUserInfo } from '@/api/supabase/user';
 import { postUploadUserImage } from '@/api/supabase/imageUpload';
 import { DEFAULT_PROFILE_IMAGE_URL } from '@/constants';
+import { errorToast } from '@/utils/toast';
 
 const router = useRouter();
 const profileStore = useProfileStore();
@@ -29,7 +30,12 @@ const handleCancel = () => {
 const handleSubmit = async () => {
   // 닉네임 중복 체크 여부 확인해야 함
   if (!profileStore.isCheckNickname) {
-    alert('닉네임 중복 확인을 해주세요.');
+    errorToast('닉네임 중복 확인을 해주세요.');
+    return;
+  }
+
+  if (profileStore.shortIntroduction.trim() === '') {
+    errorToast('한 줄 소개를 입력해주세요.');
     return;
   }
 
@@ -48,7 +54,13 @@ const handleSubmit = async () => {
   }
 
   const res = await putUserInfo(newProfile, newPositions);
-  if (res) router.push('/MyPage');
+  if (res) {
+    router.push({
+      path: '/MyPage',
+      query: { tabIndex: 0 },
+      state: { isCompleteEdit: true },
+    });
+  }
 };
 
 onMounted(() => {
@@ -58,10 +70,10 @@ onMounted(() => {
 
 <template>
   <form class="flex flex-col gap-10 pt-12 pb-20" @submit.prevent="handleSubmit">
-    <section class="p-6 card-shadow rounded-lg bg-white">
+    <section class="p-6 bg-white rounded-lg card-shadow">
       <DefaultInformation />
     </section>
-    <section class="bg-white card-shadow p-6 gap-11 flex flex-col rounded-lg">
+    <section class="flex flex-col p-6 bg-white rounded-lg card-shadow gap-11">
       <ProfileIntroduction />
       <ProfileLinks />
       <ProfilePositions />

--- a/src/pages/EditProfilePage/components/DefaultInformation.vue
+++ b/src/pages/EditProfilePage/components/DefaultInformation.vue
@@ -87,28 +87,30 @@ const handleFileChange = (event) => {
     <section class="flex flex-col items-center">
       <DropdownButton>
         <template #trigger="{ toggleDropdown }">
-          <div class="group w-[190px] h-[190px] rounded-full relative overflow-hidden input-shadow">
+          <div
+            class="group w-[190px] h-[190px] rounded-full relative overflow-hidden user-Profile-img-shadow"
+          >
             <button
               type="button"
               class="absolute w-[190px] h-[190px] bg-black/60 hidden group-hover:flex items-center justify-center"
               @click="toggleDropdown"
             >
-              <PencilIcon class="text-white w-6 h-6" />
+              <PencilIcon class="w-6 h-6 text-white" />
             </button>
             <img
               v-if="profileImage.local"
               :src="profileImage.local"
               alt="프로필 이미지"
-              class="w-full h-full object-cover object-bottom"
+              class="object-cover object-bottom w-full h-full"
             />
-            <div else class="bg-primary-5 w-full h-full" />
+            <div else class="w-full h-full bg-primary-5" />
           </div>
         </template>
         <template #menu="{ isOpen, closeDropdown }">
           <DropdownMenu
             :isOpen="isOpen"
             :dropdownList="dropdownList"
-            class="top-1/2 -translate-y-1/2 left-1/2 ml-6"
+            class="ml-6 -translate-y-1/2 top-1/2 left-1/2"
             @onClose="closeDropdown"
           />
         </template>
@@ -122,7 +124,7 @@ const handleFileChange = (event) => {
           :value="newNickname"
           placeholder="닉네임"
           :maxLength="MAX_NICKNAME_LENGTH"
-          class="pr-2 py-2"
+          class="py-2 pr-2"
           @input="handleNickNameInput"
         >
           <template #rightIcon>
@@ -149,7 +151,7 @@ const handleFileChange = (event) => {
           :maxLength="MAX_SHORT_INTRODUCE_LENGTH"
           @input="handleShortIntroductionInput"
         />
-        <p class="body-r text-gray-50 justify-self-end mt-1">
+        <p class="mt-1 body-r text-gray-50 justify-self-end">
           {{ shortIntroduction.length }}/{{ MAX_SHORT_INTRODUCE_LENGTH }}
         </p>
       </section>

--- a/src/pages/Mypage/MyPage.vue
+++ b/src/pages/Mypage/MyPage.vue
@@ -29,12 +29,6 @@ const handleEditProfile = () => {
 };
 
 onMounted(async () => {
-  // edit에서 넘어온 경우 완료되었다는 토스트 메시지 보여주기
-  if (history.state.isCompleteEdit) {
-    successToast('프로필 수정이 완료되었습니다.');
-    history.replaceState(null, '', location.href);
-  }
-
   // 탭의 갯수보다 큰 index 임의 조작시 0으로 강제 전환
   if (route.query.tabIndex > items.length || !route.query.tabIndex) {
     activeIndex.value = 0;
@@ -47,7 +41,14 @@ onMounted(async () => {
 
 // 사용자 좋아요 업데이트
 onMounted(async () => {
-  await userStore.setUserPostLikes();
+  // edit에서 넘어온 경우 완료되었다는 토스트 메시지 보여주기
+  if (history.state.isCompleteEdit) {
+    successToast('프로필 수정이 완료되었습니다.');
+    history.replaceState(null, '', location.href);
+    await userStore.refetchUserInfo();
+  } else {
+    await userStore.setUserPostLikes();
+  }
 });
 
 // 탭의 인덱스 변경

--- a/src/pages/Mypage/MyPage.vue
+++ b/src/pages/Mypage/MyPage.vue
@@ -12,6 +12,7 @@ import { useRoute } from 'vue-router';
 import LoadingPage from '../LoadingPage.vue';
 import { useUserStore } from '@/stores/user';
 import { storeToRefs } from 'pinia';
+import { successToast } from '@/utils/toast';
 
 const items = ['내 정보', '작성한 모집글', '신청 목록', '찜 목록'];
 const activeIndex = ref(0);
@@ -28,6 +29,12 @@ const handleEditProfile = () => {
 };
 
 onMounted(async () => {
+  // edit에서 넘어온 경우 완료되었다는 토스트 메시지 보여주기
+  if (history.state.isCompleteEdit) {
+    successToast('프로필 수정이 완료되었습니다.');
+    history.replaceState(null, '', location.href);
+  }
+
   // 탭의 갯수보다 큰 index 임의 조작시 0으로 강제 전환
   if (route.query.tabIndex > items.length || !route.query.tabIndex) {
     activeIndex.value = 0;
@@ -61,7 +68,11 @@ const handleUpdateIndex = (index = 0) => {
     >
       <!-- 프로필 이미지 -->
       <div class="w-[124px] h-[124px]">
-        <img class="w-full h-full rounded-full" :src="user.profile_img_path" alt="프로필 이미지" />
+        <img
+          class="w-full h-full rounded-full user-Profile-img-shadow"
+          :src="user.profile_img_path"
+          alt="프로필 이미지"
+        />
       </div>
       <!-- 프로필 정보 -->
       <div class="flex flex-col items-start gap-[16px] flex-1">

--- a/src/pages/RecruitPostDetailPage/RecruitPostDetailPage.vue
+++ b/src/pages/RecruitPostDetailPage/RecruitPostDetailPage.vue
@@ -121,7 +121,7 @@ watchEffect(async () => {
                 v-if="postDetails.user.profile_img_path"
                 :src="postDetails.user.profile_img_path"
                 alt="User Profile Image"
-                class="w-[33px] h-[33px] rounded-full"
+                class="w-[33px] h-[33px] rounded-full user-Profile-img-shadow"
               />
             </div>
             <div>
@@ -154,7 +154,7 @@ watchEffect(async () => {
         <div class="mb-8">
           <p
             v-html="postDetails.body"
-            class="text-gray-700 leading-relaxed whitespace-pre-wrap"
+            class="leading-relaxed text-gray-700 whitespace-pre-wrap"
           ></p>
         </div>
         <hr class="my-10 text-gray-10" />

--- a/src/pages/RecruitPostDetailPage/components/PostApplyList.vue
+++ b/src/pages/RecruitPostDetailPage/components/PostApplyList.vue
@@ -1,7 +1,7 @@
 <script setup>
 import AppButton from '@/components/AppButton.vue';
 import { ref, onMounted } from 'vue';
-import { getApplicationsForMyPosts, getMyApplicationsList } from '@/api/supabase/apply';
+import { getApplicationsForMyPosts } from '@/api/supabase/apply';
 import { supabase } from '@/config/supabase';
 
 const postId = 92;
@@ -112,7 +112,7 @@ const handleReject = async (proposerId) => {
             <img
               src="@/assets/images/default_user_img.png"
               alt="Profile Image"
-              class="w-12 h-12 rounded-full"
+              class="w-12 h-12 rounded-full user-Profile-img-shadow"
             />
             <div>
               <p class="font-semibold flex items-center gap-2 text-base">

--- a/src/pages/RecruitPostDetailPage/components/PostComment.vue
+++ b/src/pages/RecruitPostDetailPage/components/PostComment.vue
@@ -10,7 +10,7 @@ import DropdownMenu from '@/components/DropdownMenu.vue';
 import { useBaseModalStore } from '@/stores/baseModal';
 import { useUserStore } from '@/stores/user';
 import { storeToRefs } from 'pinia';
-import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, reactive, ref } from 'vue';
 import { useRoute } from 'vue-router';
 
 const props = defineProps({
@@ -222,7 +222,7 @@ onUnmounted(() => {
             <img
               :src="comment.commenter_image_path"
               alt="프로필 이미지"
-              class="w-10 h-10 rounded-full object-cover mr-4 card-shadow"
+              class="object-cover w-10 h-10 mr-4 rounded-full user-Profile-img-shadow"
             />
             <div>
               <p class="font-semibold text-gray-800">{{ comment.commenter_name }}</p>

--- a/src/pages/UserPage/UserPage.vue
+++ b/src/pages/UserPage/UserPage.vue
@@ -69,15 +69,15 @@ const handleUpdateIndex = (index = 0) => {
         <img
           :src="userInfo.profile_img_path"
           alt="프로필 이미지"
-          class="w-[165px] h-[165px] rounded-full"
+          class="w-[165px] h-[165px] rounded-full user-Profile-img-shadow"
         />
       </div>
       <!-- 프로필 정보 -->
-      <div class="flex flex-col items-start gap-4 flex-1">
+      <div class="flex flex-col items-start flex-1 gap-4">
         <div class="flex flex-col items-start flex-1 w-full gap-1">
-          <p class="h2-b text-black">{{ userInfo.name }}</p>
+          <p class="text-black h2-b">{{ userInfo.name }}</p>
 
-          <div class="flex justify-between items-center w-full">
+          <div class="flex items-center justify-between w-full">
             <p class="body-large-r text-gray-40">{{ userInfo.short_introduce }}</p>
           </div>
         </div>

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -23,6 +23,13 @@ export const useUserStore = defineStore('user', () => {
     console.log('확인', user.value);
   };
 
+  const refetchUserInfo = async () => {
+    // 의도적인 재요청
+    const userInfo = await getUserInfo();
+    if (userInfo === null) return;
+    user.value = userInfo;
+  };
+
   const setUserPostLikes = async () => {
     const res = await getUserPostLikes();
     if (res) {
@@ -52,9 +59,10 @@ export const useUserStore = defineStore('user', () => {
   return {
     user,
     isLoggedIn,
+    userPostLikes,
     checkLoginStatus,
     fetchUserInfo,
-    userPostLikes,
+    refetchUserInfo,
     setUserPostLikes,
     updateLikes,
     updateBookmarks,

--- a/src/utils/toast.js
+++ b/src/utils/toast.js
@@ -36,7 +36,7 @@ export const infoToast = (text, options = {}) => {
 export const warningToast = (text, options = {}) => {
   toast.info(text, {
     autoClose: 3000,
-    position: warning.POSITION.TOP_RIGHT,
+    position: toast.POSITION.TOP_RIGHT,
     ...options,
   });
 };


### PR DESCRIPTION
## 🪄 변경 사항
- resolved #103 
### 마이페이지 수정 토스트 메시지 적용
- 마이페이지에서 닉네임 중복을 하지 않거나 한 줄 소개를 입력하지 않을 때만 토스트 메시지가 보이도록 했습니다.
- 수정이 완료된 후, 마이 페이지로 이동할 경우 프로필 수정이 완료되었다는 토스트 메시지가 띄워지도록 했습니다.

### 프로필 이미지에 shadow 적용
- 저번에 예지님이 만들어주신 shadow를 프로필 이미지 사용되는 곳을 싹다 찾아내서 적용했어요!
- 그래서... 실은 모든 분들에게 충돌이 발생하지 않을까 싶은데... 충돌이 우려가 된다면,, 커밋을 되돌리겠습니다!
- 제가 아까 Headwind를 적용하는 바람에 다른 것까지 수정이 되어버려서 급하게 끄고 되돌렸는데 몇개를 놓친 것 같습니다ㅠ (tailwind 코드 순서 변경된 문제)

### 프로필 수정 후 마이페이지에 반영 안되는 문제 해결
- 마이페이지에서 피니아로 관리 중인 유저 정보로 보여주고 있었고, 이를 업데이트 하지 않은 문제라는 점을 확인했습니다.
- 프로필 수정 페이지에서 마이페이지로 넘어온 경우에만 유저 정보를 다시 가져올 수 있도록 수정했습니다.

## 💡 반영 브랜치
- feat-edit-profile-toast-#103

## 🖼️ 결과 화면 (생략 가능)
생략

## 💬 리뷰어에게 전할 말
