### PR TITLE
fix : 각종  페이지 보완

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,8 +13,8 @@ onMounted(async () => {
     if (isLoggedIn.value) {
       await userStore.fetchUserInfo();
     }
-    console.log('로그인 상태:', isLoggedIn.value);
-    console.log('User info:', user.value);
+    // console.log('로그인 상태:', isLoggedIn.value);
+    // console.log('User info:', user.value);
 
     // 사용자 정보가 없고 로그인 상태일 때 온보딩으로 이동
     if (!user.value && isLoggedIn.value) {

--- a/src/api/supabase/notifications.js
+++ b/src/api/supabase/notifications.js
@@ -77,7 +77,6 @@ export const getNotificationsHandle = async (userId) => {
 
 export const getNotifications = async () => {
   const user = await getUserInfo();
-  console.log(user);
 
   const { data, error } = await supabase
     .from('notifications')

--- a/src/api/supabase/post.js
+++ b/src/api/supabase/post.js
@@ -54,7 +54,7 @@ export const getAllPosts = async (filters, size = 10) => {
   }
 };
 
-// // 특정 페이지의 게시물을 보여주는 API (1페이지당 12개 보여주기)
+// 특정 페이지의 게시물을 보여주는 API (1페이지당 12개 보여주기)
 // export const getAllPostsWithPagination = async (filters, page = 1, pageSize = 12) => {
 //   try {
 //     const from = (page - 1) * pageSize;
@@ -139,18 +139,13 @@ export const getAllPosts = async (filters, size = 10) => {
 
 export const getAllPostsWithPagination = async (filters, page = 1, page_size = 12) => {
   try {
-    console.log('Filters before sending:', filters);
-    // filters 객체의 타입도 확인
-    console.log('Type of stacks:', Array.isArray(filters.stacks) ? 'array' : typeof filters.stacks);
-
     let { data, error } = await supabase.rpc('get_filtered_posts_with_pagination', {
       filters,
       page,
       page_size,
     });
     if (error) console.error(error);
-    else console.log(data);
-    return data;
+    else return data;
   } catch (error) {
     console.error(error);
     return { posts: [], total_post: 0, page, total_page: 0 };

--- a/src/api/supabase/post.js
+++ b/src/api/supabase/post.js
@@ -2,119 +2,162 @@ import { supabase } from '@/config/supabase';
 import { getPostComments } from '@/api/supabase/comment';
 import { getUserInfoToUserId } from './user';
 
-// 전체 게시물을 보여주는 API ( 페이지네이션 x)
-export const getAllPosts = async () => {
+// 전체 게시물을 보여주는 API
+// export const getAllPosts = async (filters, size = 10) => {
+//   try {
+//     let query = supabase
+//       .from('post')
+//       .select('*', { count: 'exact' })
+//       .order('created_at', { ascending: false });
+
+//     if ((filters.order = '최신순')) {
+//       query = query.order('created_at', { ascending: false });
+//     }
+//     if ((filters.order = '마감일순')) {
+//       query = query.order('recruit_deadline', { ascending: true });
+//     }
+//     query = query.range(0, size);
+
+//     const { data, error } = await query; // 수정된 부분
+//     if (error) {
+//       throw new Error(error);
+//     }
+
+//     const totalData = await Promise.all(
+//       data.map(async (item) => {
+//         const userInfo = await getUserInfoToUserId(item.author);
+//         return {
+//           ...item,
+//           name: userInfo.name,
+//           profile_img_path: userInfo.profile_img_path,
+//           positions: await getPostPositions(item.id),
+//           techStacks: await getPostTechStacks(item.id),
+//         };
+//       }),
+//     );
+//     return totalData;
+//   } catch (error) {
+//     console.error(error);
+//   }
+// };
+
+export const getAllPosts = async (filters, size = 10) => {
   try {
-    const { data, error } = await supabase
-      .from('post')
-      .select('*', { count: 'exact' })
-      .order('created_at', { ascending: false });
-    if (error) {
-      throw new Error(error);
-    }
-
-    const totalData = await Promise.all(
-      data.map(async (item) => {
-        const userInfo = await getUserInfoToUserId(item.author);
-
-        return {
-          ...item,
-          name: userInfo.name,
-          profile_img_path: userInfo.profile_img_path,
-          positions: await getPostPositions(item.id),
-          techStacks: await getPostTechStacks(item.id),
-        };
-      }),
-    );
-    return totalData;
+    let { data, error } = await supabase.rpc('get_all_posts', {
+      filters,
+      size,
+    });
+    if (error) console.error(error);
+    else return data;
   } catch (error) {
     console.error(error);
   }
 };
 
-// 특정 페이지의 게시물을 보여주는 API (1페이지당 12개 보여주기)
-export const getAllPostsWithPagination = async (filters, page = 1, pageSize = 12) => {
+// // 특정 페이지의 게시물을 보여주는 API (1페이지당 12개 보여주기)
+// export const getAllPostsWithPagination = async (filters, page = 1, pageSize = 12) => {
+//   try {
+//     const from = (page - 1) * pageSize;
+//     const to = page * pageSize - 1;
+//     console.log(filters);
+
+//     // 기술 스택 요소를 포함하는 post_id를 담을 배열
+//     let matchingPostIds = [];
+//     if (filters.stacks && filters.stacks.length > 0) {
+//       const { data: stackData } = await supabase
+//         .from('post_stacks')
+//         .select('post_id')
+//         .or(filters.stacks.map((tech) => `stack.ilike.%${tech}%`).join(','));
+
+//       matchingPostIds = stackData?.map((item) => item.post_id) || [];
+
+//       if (matchingPostIds.length === 0) {
+//         return { data: [], totalPost: 0, page, totalPage: 0 };
+//       }
+//     }
+
+//     // 쿼리 체이닝 방식을 사용시 await을 마지막에 단 한번 실행
+//     // post_positions 테이블을 post 테이블과 inner join
+//     let query = supabase
+//       .from('post')
+//       .select(`*,post_positions!inner(position)`, { count: 'exact' })
+//       .order('created_at', { ascending: false });
+
+//     if (matchingPostIds.length > 0) {
+//       query = query.in('id', matchingPostIds);
+//     }
+//     if (filters.position && filters.position !== '전체') {
+//       query = query.ilike('post_positions.position', `%${filters.position}%`);
+//     }
+//     if (filters.recruitArea && filters.recruitArea !== '전체') {
+//       query = query.ilike('recruit_area', `%${filters.recruitArea}%`); // 수정된 부분
+//     }
+//     if (filters.recruitType) {
+//       query = query.ilike('recruit_type', filters.recruitType);
+//     }
+//     if (filters.onOffline && filters.onOffline !== '전체') {
+//       query = query.ilike('on_offline', `%${filters.onOffline}%`); // 수정된 부분
+//     }
+//     //like, is 연산자는 문자열 비교에만 사용된다.
+//     //  boolean 타입은  eq로 비교해야한다.
+//     if (typeof filters.finished === 'boolean' && filters.finished) {
+//       query = query.eq('finished', filters.finished); // 수정된 부분
+//     }
+//     if (filters.searchResults) {
+//       query = query.or(`title.ilike.%${filters.searchResults}%`);
+//     }
+
+//     query = query.range(from, to);
+//     const { data, error, count } = await query; // 수정된 부분
+
+//     if (error) {
+//       throw new Error(error);
+//     }
+
+//     const total_page = Math.ceil((count || 0) / pageSize);
+
+//     const totalData = await Promise.all(
+//       data.map(async (item) => {
+//         const userInfo = await getUserInfoToUserId(item.author);
+
+//         return {
+//           ...item,
+//           name: userInfo.name,
+//           profile_img_path: userInfo.profile_img_path,
+//           positions: await getPostPositions(item.id),
+//           tech_stacks: await getPostTechStacks(item.id),
+//         };
+//       }),
+//     );
+
+//     return { posts: totalData, total_post: count, page, total_page };
+//   } catch (error) {
+//     console.error(error);
+//     return { posts: [], total_post: 0, page, total_page: 0 };
+//   }
+// };
+
+export const getAllPostsWithPagination = async (filters, page = 1, page_size = 12) => {
   try {
-    const from = (page - 1) * pageSize;
-    const to = page * pageSize - 1;
+    console.log('Filters before sending:', filters);
+    // filters 객체의 타입도 확인
+    console.log('Type of stacks:', Array.isArray(filters.stacks) ? 'array' : typeof filters.stacks);
 
-    // 기술 스택 요소를 포함하는 post_id를 담을 배열
-    let matchingPostIds = [];
-    if (filters.techStack && filters.techStack.length > 0) {
-      const { data: stackData } = await supabase
-        .from('post_stacks')
-        .select('post_id')
-        .or(filters.techStack.map((tech) => `stack.ilike.%${tech}%`).join(','));
-
-      matchingPostIds = stackData?.map((item) => item.post_id) || [];
-
-      if (matchingPostIds.length === 0) {
-        return { data: [], totalPost: 0, page, totalPage: 0 };
-      }
-    }
-
-    // 쿼리 체이닝 방식을 사용시 await을 마지막에 단 한번 실행
-    // post_positions 테이블을 post 테이블과 inner join
-    let query = supabase
-      .from('post')
-      .select(`*,post_positions!inner(position)`, { count: 'exact' })
-      .order('created_at', { ascending: false });
-
-    if (matchingPostIds.length > 0) {
-      query = query.in('id', matchingPostIds);
-    }
-    if (filters.position && filters.position !== '전체') {
-      query = query.ilike('post_positions.position', `%${filters.position}%`);
-    }
-    if (filters.recruitArea && filters.recruitArea !== '전체') {
-      query = query.ilike('recruit_area', `%${filters.recruitArea}%`); // 수정된 부분
-    }
-    if (filters.recruitType) {
-      query = query.ilike('recruit_type', filters.recruitType);
-    }
-    if (filters.onOffline && filters.onOffline !== '전체') {
-      query = query.ilike('on_offline', `%${filters.onOffline}%`); // 수정된 부분
-    }
-    //like, is 연산자는 문자열 비교에만 사용된다.
-    //  boolean 타입은  eq로 비교해야한다.
-    if (typeof filters.finished === 'boolean' && filters.finished) {
-      query = query.eq('finished', filters.finished); // 수정된 부분
-    }
-    if (filters.searchResults) {
-      query = query.or(`title.ilike.%${filters.searchResults}%`);
-    }
-
-    query = query.range(from, to);
-    const { data, error, count } = await query; // 수정된 부분
-
-    if (error) {
-      throw new Error(error);
-    }
-
-    const total_page = Math.ceil((count || 0) / pageSize);
-
-    const totalData = await Promise.all(
-      data.map(async (item) => {
-        const userInfo = await getUserInfoToUserId(item.author);
-
-        return {
-          ...item,
-          name: userInfo.name,
-          profile_img_path: userInfo.profile_img_path,
-          positions: await getPostPositions(item.id),
-          techStacks: await getPostTechStacks(item.id),
-        };
-      }),
-    );
-
-    return { posts: totalData, total_post: count, page, total_page };
+    let { data, error } = await supabase.rpc('get_filtered_posts_with_pagination', {
+      filters,
+      page,
+      page_size,
+    });
+    if (error) console.error(error);
+    else console.log(data);
+    return data;
   } catch (error) {
     console.error(error);
     return { posts: [], total_post: 0, page, total_page: 0 };
   }
 };
 
-// 내가 신청한 목록
+// // 내가 신청한 목록
 export const getMyApplyPosts = async (filters, page = 1, pageSize = 8) => {
   try {
     const from = (page - 1) * pageSize;

--- a/src/api/supabase/user.js
+++ b/src/api/supabase/user.js
@@ -125,7 +125,7 @@ export const getUserInfo = async () => {
   );
 
   const realProfile = { ...getProfile, link: getProfile.link.split('*') };
-  console.log({ ...realProfile, positions: positions });
+  // console.log({ ...realProfile, positions: positions });
   return { ...realProfile, positions: positions };
 };
 

--- a/src/components/PostCard.vue
+++ b/src/components/PostCard.vue
@@ -11,14 +11,6 @@ import { storeToRefs } from 'pinia';
 import { toggleBookmark, toggleLike } from '@/api/supabase/like_and_bookmark';
 import { useLoginModalStore } from '@/stores/loginModal';
 import { useUserProfileModalStore } from '@/stores/userProfileModal';
-import { usePagination } from '@/utils/usePagination';
-
-// const queryClient = useQueryClient();
-// const postMutation = useMutation(fetchData, {
-//   onSuccess: () => {
-//     queryClient.invalidateQueries([queryKey]);
-//   },
-// });
 
 // 로그인 확인 여부
 const userStore = useUserStore();

--- a/src/components/PostCard.vue
+++ b/src/components/PostCard.vue
@@ -11,6 +11,14 @@ import { storeToRefs } from 'pinia';
 import { toggleBookmark, toggleLike } from '@/api/supabase/like_and_bookmark';
 import { useLoginModalStore } from '@/stores/loginModal';
 import { useUserProfileModalStore } from '@/stores/userProfileModal';
+import { usePagination } from '@/utils/usePagination';
+
+// const queryClient = useQueryClient();
+// const postMutation = useMutation(fetchData, {
+//   onSuccess: () => {
+//     queryClient.invalidateQueries([queryKey]);
+//   },
+// });
 
 // 로그인 확인 여부
 const userStore = useUserStore();

--- a/src/components/UserProfileModal.vue
+++ b/src/components/UserProfileModal.vue
@@ -4,6 +4,7 @@ import { useUserProfileModalStore } from '@/stores/userProfileModal';
 import { useProfileStore } from '@/stores/profile';
 import { storeToRefs } from 'pinia';
 import PositionSmallBadge from '@/components/PositionSmallBadge.vue';
+import { useUserStore } from '@/stores/user';
 
 const userProfileModalStore = useUserProfileModalStore();
 const { userProfileModal, userInfo, isLoading, error } = storeToRefs(userProfileModalStore);
@@ -14,6 +15,8 @@ const { DEFAULT_PROFILE_IMAGE_URL } = profileStore;
 const closeUserProfile = () => {
   userProfileModalStore.setUserProfileModal(false);
 };
+const userStore = useUserStore();
+const { user } = storeToRefs(userStore);
 
 const handleUserPageClick = () => {
   closeUserProfile();
@@ -60,11 +63,22 @@ const handleUserPageClick = () => {
           </ul>
           <p class="body-large-r text-gray-80">{{ userInfo.short_introduce || '' }}</p>
         </div>
-        <RouterLink :to="`/UserPage/${userInfo.id}`" @click="handleUserPageClick">
+        <RouterLink
+          v-if="user.user_id !== userInfo.id"
+          :to="`/UserPage/${userInfo.id}`"
+          @click="handleUserPageClick"
+        >
           <button
             class="w-[300px] h-[45px] py-3 px-[10px] rounded-lg body-r text-white bg-primary-hover/80"
           >
             유저 페이지로 이동하기
+          </button>
+        </RouterLink>
+        <RouterLink v-else :to="`/mypage`" @click="handleUserPageClick">
+          <button
+            class="w-[300px] h-[45px] py-3 px-[10px] rounded-lg body-r text-white bg-primary-hover/80"
+          >
+            마이 페이지로 이동하기
           </button>
         </RouterLink>
       </template>

--- a/src/pages/MainPage/MainPage.vue
+++ b/src/pages/MainPage/MainPage.vue
@@ -11,52 +11,41 @@ import talk from '@/assets/images/talk.png';
 import { getAllPosts } from '@/api/supabase/post';
 import { useUserStore } from '@/stores/user';
 import SwipeablePostSection from '@/pages/MainPage/components/SwipeablePostSection.vue';
+import LoadingPage from '../LoadingPage.vue';
 
 const hotPosts = ref([]);
 const deadlinePosts = ref([]);
 const newPosts = ref([]);
-const isLoading = ref(true);
+const loading = ref(true);
 
 // 포스트 카드 렌더링 상수
 const VISIBLE_POSTS = 4;
-const TOTAL_POSTS = 10;
 
 // 포스트 정렬
-const sortPosts = {
-  hot: (posts) => posts.sort((a, b) => b.likes - a.likes),
-  deadline: (posts) =>
-    posts.sort((a, b) => new Date(a.applicationDeadline) - new Date(b.applicationDeadline)),
-  new: (posts) => posts.sort((a, b) => new Date(b.created_at) - new Date(a.created_at)),
-};
+// const sortPosts = {
+//   hot: (posts) => posts.sort((a, b) => b.likes - a.likes),
+//   deadline: (posts) =>
+//     posts.sort((a, b) => new Date(a.applicationDeadline) - new Date(b.applicationDeadline)),
+//   new: (posts) => posts.sort((a, b) => new Date(b.created_at) - new Date(a.created_at)),
+// };
 
 // 포스트카드 API 호출
 const fetchPosts = async () => {
-  isLoading.value = true;
+  loading.value = true;
   try {
-    const data = await getAllPosts();
-    if (Array.isArray(data)) {
-      // 포스트 데이터 매핑 함수
-      const mapPost = (post) => ({
-        id: post.id,
-        user_id: post.author,
-        userImage: post.profile_img_path,
-        userName: post.name,
-        projectTitle: post.title,
-        skills: post.techStacks || [],
-        position: post.positions || [],
-        applicationDeadline: post.recruit_deadline,
-      });
-
-      hotPosts.value = sortPosts.hot(data).slice(0, TOTAL_POSTS).map(mapPost);
-      deadlinePosts.value = sortPosts.deadline(data).slice(0, TOTAL_POSTS).map(mapPost);
-      newPosts.value = sortPosts.new(data).slice(0, TOTAL_POSTS).map(mapPost);
-    } else {
-      console.error('게시글을 불러오는데 실패했습니다', data);
-    }
+    const [hot, deadline, recently] = await Promise.all([
+      getAllPosts({ order: '인기순' }),
+      getAllPosts({ order: '마감일순' }),
+      getAllPosts({ order: '최신순' }),
+    ]);
+    hotPosts.value = hot.posts;
+    deadlinePosts.value = deadline.posts;
+    newPosts.value = recently.posts;
+    console.log(hotPosts.value);
   } catch (error) {
     console.error('게시글 로딩 중 오류 발생:', error);
   } finally {
-    isLoading.value = false;
+    loading.value = false;
   }
 };
 
@@ -64,77 +53,76 @@ const fetchPosts = async () => {
 const userStore = useUserStore();
 onMounted(async () => {
   await userStore.setUserPostLikes();
-  console.log('좋아요 업데이트', userStore.userPostLikes);
-});
-
-onMounted(() => {
-  fetchPosts();
+  await fetchPosts();
 });
 </script>
 
 <template>
-  <section class="pt-10 mb-20">
-    <div class="mb-5"><img :src="mainBanner" alt="mainBanner" /></div>
-    <div class="flex flex-wrap gap-5">
-      <MainSmallBanner
-        to="/PostList/study"
-        bgColor="bg-secondary-2"
-        bannerCaption="모집 중인 스터디를 찾아보세요"
-        :icon="pencil"
-        iconAlt="pencilIcon"
-        title="스터디 보러가기"
-        :bannerImage="mainStudyBanner"
-        bannerAlt="mainStudyBanner"
-        imagePosition="top-[64px] right-5"
+  <LoadingPage v-if="loading" />
+  <div v-else>
+    <section class="pt-10 mb-20">
+      <div class="mb-5"><img :src="mainBanner" alt="mainBanner" /></div>
+      <div class="flex flex-wrap gap-5">
+        <MainSmallBanner
+          to="/PostList/study"
+          bgColor="bg-secondary-2"
+          bannerCaption="모집 중인 스터디를 찾아보세요"
+          :icon="pencil"
+          iconAlt="pencilIcon"
+          title="스터디 보러가기"
+          :bannerImage="mainStudyBanner"
+          bannerAlt="mainStudyBanner"
+          imagePosition="top-[64px] right-5"
+        />
+        <MainSmallBanner
+          to="/PostList/project"
+          bgColor="bg-secondary-1"
+          bannerCaption="모집 중인 프로젝트를 찾아보세요"
+          :icon="search"
+          iconAlt="searchIcon"
+          title="프로젝트 보러가기"
+          :bannerImage="mainProjectBanner"
+          bannerAlt="mainProjectBanner"
+          imagePosition="top-[68px] right-5"
+        />
+        <MainSmallBanner
+          to="/service"
+          bgColor="bg-primary-5"
+          bannerCaption="홍보 중인 서비스를 구경해 보세요"
+          :icon="talk"
+          iconAlt="talkIcon"
+          title="서비스 보러가기"
+          :bannerImage="mainServiceBanner"
+          bannerAlt="mainServiceBanner"
+          imagePosition="top-[41px] right-[26px]"
+        />
+      </div>
+    </section>
+    <section class="space-y-8">
+      <SwipeablePostSection
+        title="Hot 인기있는 "
+        badgeText="인기있는"
+        badgeStatus="success"
+        :posts="hotPosts"
+        :visiblePosts="VISIBLE_POSTS"
+        :isLoading="loading"
       />
-      <MainSmallBanner
-        to="/PostList/project"
-        bgColor="bg-secondary-1"
-        bannerCaption="모집 중인 프로젝트를 찾아보세요"
-        :icon="search"
-        iconAlt="searchIcon"
-        title="프로젝트 보러가기"
-        :bannerImage="mainProjectBanner"
-        bannerAlt="mainProjectBanner"
-        imagePosition="top-[68px] right-5"
+      <SwipeablePostSection
+        title="Now 곧 마감되는 "
+        badgeText="마감직전"
+        badgeStatus="danger"
+        :posts="deadlinePosts"
+        :visiblePosts="VISIBLE_POSTS"
+        :isLoading="loading"
       />
-      <MainSmallBanner
-        to="/service"
-        bgColor="bg-primary-5"
-        bannerCaption="홍보 중인 서비스를 구경해 보세요"
-        :icon="talk"
-        iconAlt="talkIcon"
-        title="서비스 보러가기"
-        :bannerImage="mainServiceBanner"
-        bannerAlt="mainServiceBanner"
-        imagePosition="top-[41px] right-[26px]"
+      <SwipeablePostSection
+        title="New 새로운 "
+        badgeText="새로운"
+        badgeStatus="warning"
+        :posts="newPosts"
+        :visiblePosts="VISIBLE_POSTS"
+        :isLoading="loading"
       />
-    </div>
-  </section>
-  <section class="space-y-8">
-    <SwipeablePostSection
-      title="Hot 인기있는 프로젝트"
-      badgeText="인기있는"
-      badgeStatus="success"
-      :posts="hotPosts"
-      :visiblePosts="VISIBLE_POSTS"
-      :isLoading="isLoading"
-    />
-    <SwipeablePostSection
-      title="Now 곧 마감되는 프로젝트"
-      badgeText="마감직전"
-      badgeStatus="danger"
-      :posts="deadlinePosts"
-      :visiblePosts="VISIBLE_POSTS"
-      :isLoading="isLoading"
-    />
-    <SwipeablePostSection
-      title="New 새로운 프로젝트"
-      badgeText="새로운"
-      badgeStatus="warning"
-      :posts="newPosts"
-      :visiblePosts="VISIBLE_POSTS"
-      :isLoading="isLoading"
-    />
-  </section>
+    </section>
+  </div>
 </template>

--- a/src/pages/MainPage/components/PostSection.vue
+++ b/src/pages/MainPage/components/PostSection.vue
@@ -57,7 +57,19 @@ defineProps({
         </div>
       </template>
       <!-- 데이터 호출 완료된 뒤 -->
-      <PostCard v-else v-for="post in posts" :key="post.id" v-bind="post" />
+      <PostCard
+        v-else
+        v-for="post in posts"
+        :key="post.id"
+        :id="post.id"
+        :user_id="post.author"
+        :user-image="post.profile_img_path"
+        :user-name="post.name"
+        :project-title="post.title"
+        :skills="post.tech_stacks"
+        :position="post.positions"
+        :application-deadline="post.recruit_deadline"
+      />
     </div>
   </article>
 </template>

--- a/src/pages/MainPage/components/SwipeablePostSection.vue
+++ b/src/pages/MainPage/components/SwipeablePostSection.vue
@@ -25,6 +25,7 @@ const visiblePosts = computed(() => {
     const index = (startIndex.value + i) % props.posts.length;
     visiblePosts.push(props.posts[index]);
   }
+
   return visiblePosts;
 });
 

--- a/src/pages/Mypage/components/LargePostCard.vue
+++ b/src/pages/Mypage/components/LargePostCard.vue
@@ -40,6 +40,8 @@ const baseModal = useBaseModalStore();
 const handleOpenModal = () => {
   baseModal.showModal({
     title: '신청을 취소하시겠습니까?',
+    confirmText: '취소하기',
+    cancelText: '돌아가기',
     onConfirm: async () => await deleteApplicationHandle(props.postId),
   });
 };

--- a/src/pages/Mypage/components/MyBookmark.vue
+++ b/src/pages/Mypage/components/MyBookmark.vue
@@ -6,8 +6,10 @@ import LoadingPage from '@/pages/LoadingPage.vue';
 import PostPagination from '@/pages/PostListPage/components/PostPagination.vue';
 import { usePagination } from '@/utils/usePagination';
 import { onMounted } from 'vue';
+import { useRouter } from 'vue-router';
 
 const orderFilterList = ['최신순', '오래된순', '인기순', '마감일순'];
+const router = useRouter();
 
 onMounted(() => {
   fetchUserBookmarkWithPagination();
@@ -32,9 +34,14 @@ const {
   selectedFilter,
   handleChangePage,
   handleUpdateFilter,
-} = usePagination(fetchUserBookmarkWithPagination, 'filteredBookmarkPosts', {
-  order: '최신순',
-});
+} = usePagination(
+  fetchUserBookmarkWithPagination,
+  'filteredBookmarkPosts',
+  {
+    order: '최신순',
+  },
+  false,
+);
 
 const handleSelectOrder = (order) => {
   handleUpdateFilter({ order });
@@ -54,39 +61,42 @@ const handleSelectOrder = (order) => {
     />
 
     <!-- 글이 있을때 -->
-    <div v-if="filteredPosts.length > 0" class="flex pl-1 gap-4 flex-wrap">
-      <div v-for="post in filteredPosts" :key="post.id" class="cursor-pointer">
-        <PostCard
-          :id="post.id"
-          :user-image="post.profile_img_path"
-          :user-name="post.name"
-          :project-title="post.title"
-          :skills="post.stack"
-          :position="post.post_position"
-          :application-deadline="post.end_date"
-        />
+    <div v-if="filteredPosts.length > 0" class="flex flex-col gap-7">
+      <div class="flex gap-4 flex-wrap">
+        <div v-for="post in filteredPosts" :key="post.id" class="cursor-pointer">
+          <PostCard
+            :user_id="post.author"
+            :id="post.id"
+            :user-image="post.profile_img_path"
+            :user-name="post.name"
+            :project-title="post.title"
+            :skills="post.stack"
+            :position="post.post_position"
+            :application-deadline="post.end_date"
+          />
+        </div>
       </div>
+      <PostPagination
+        :currentPage="currentPage"
+        :totalPage="totalPage"
+        @change="handleChangePage"
+        class="m-auto"
+      />
     </div>
 
-    <!-- 글이 없을때 -->
+    <!-- 목록이 없을 때 -->
     <div
-      v-else-if="filteredPosts.length === 0"
-      class="flex flex-col justify-center items-center gap-5 flex-1 h-[600px]"
+      v-else-if="filteredPosts?.length === 0"
+      class="h-[400px] flex flex-col gap-4 items-center justify-center"
     >
-      <p class="text-center text-primary-4 h3-b">찜 목록이 없습니다.</p>
-      <RouterLink
-        to="/Postlist/project"
+      <p class="text-center text-primary-4 h3-b">아직 찜한 글이 없습니다.</p>
+      <button
+        @click="router.push('/PostList/project')"
         class="bg-primary-3 text-white rounded-lg body-large-m py-2 px-6"
       >
-        찾아보러 가볼까요?
-      </RouterLink>
+        찜하러 가볼까요?
+      </button>
     </div>
-    <PostPagination
-      :currentPage="currentPage"
-      :totalPage="totalPage"
-      @change="handleChangePage"
-      class="m-auto"
-    />
   </div>
 </template>
 <style scoped></style>

--- a/src/pages/Mypage/components/MyInfo.vue
+++ b/src/pages/Mypage/components/MyInfo.vue
@@ -46,7 +46,13 @@ const introduceToggle = ref(true);
     <div v-if="links !== ''" class="flex flex-col gap-2.5">
       <span class="h3-b text-gray-80">링크</span>
       <ul class="flex flex-col gap-2.5">
-        <a :href="link" rel="noopener noreferrer" v-for="(link, index) in links" :key="index">
+        <a
+          :href="link"
+          rel="noopener noreferrer"
+          target="_blank"
+          v-for="(link, index) in links"
+          :key="index"
+        >
           <li class="flex items-center gap-5 bg-secondary-3 rounded-lg input-shadow py-[5.5px]">
             <img :src="linkIcon" alt="링크 아이콘" class="pl-4" />
             <span class="text-black body-r">{{ link }}</span>
@@ -58,9 +64,9 @@ const introduceToggle = ref(true);
     <!-- 포지션 & 스킬 -->
     <div class="flex flex-col gap-2.5">
       <span class="h3-b text-gray-80">포지션 & 스킬</span>
-      <div class="bg-secondary-3 rounded-lg input-shadow">
+      <div class="bg-secondary-3 rounded-lg input-shadow flex flex-col gap-7 p-7">
         <!-- 포지션별 기술스택 -->
-        <div class="p-7 flex flex-col gap-2.5" v-for="position in positions" :key="position.id">
+        <div class="flex flex-col gap-2.5" v-for="position in positions" :key="position.id">
           <span class="body-large-m text-black">{{ position.position }}</span>
           <div class="flex items-center gap-4">
             <div v-for="stack in position.stacks" :key="stack.id">

--- a/src/pages/Mypage/components/MyRecruitmentList.vue
+++ b/src/pages/Mypage/components/MyRecruitmentList.vue
@@ -41,9 +41,14 @@ const {
   selectedFilter,
   handleChangePage,
   handleUpdateFilter,
-} = usePagination(fetchMyPostsWithPagination, 'filteredMyPosts', {
-  order: '최신순',
-});
+} = usePagination(
+  fetchMyPostsWithPagination,
+  'filteredMyPosts',
+  {
+    order: '최신순',
+  },
+  false,
+);
 
 const handleSelectOrder = (order) => {
   handleUpdateFilter({ order });
@@ -62,40 +67,44 @@ const handleSelectOrder = (order) => {
       defaultText="정렬 순서"
       @click:select="handleSelectOrder"
     />
+
     <!-- 모집 글이 있을때 -->
-    <div v-if="filteredPosts?.length > 0" class="flex pl-1 gap-4 flex-wrap">
-      <div v-for="post in filteredPosts" :key="post.id" class="cursor-pointer">
-        <PostCard
-          :id="post.id"
-          :user-image="user.profile_img_path"
-          :user-name="user.name"
-          :project-title="post.title"
-          :skills="post.tech_stacks"
-          :position="post.positions"
-          :application-deadline="post.end_date"
-        />
+    <div v-if="filteredPosts?.length > 0" class="flex flex-col gap-7">
+      <div class="flex pl-1 gap-4 flex-wrap">
+        <div v-for="post in filteredPosts" :key="post.id" class="cursor-pointer">
+          <PostCard
+            :user_id="post.author"
+            :id="post.id"
+            :user-image="user.profile_img_path"
+            :user-name="user.name"
+            :project-title="post.title"
+            :skills="post.tech_stacks"
+            :position="post.positions"
+            :application-deadline="post.end_date"
+          />
+        </div>
       </div>
+      <PostPagination
+        :currentPage="currentPage"
+        :totalPage="totalPage"
+        @change="handleChangePage"
+        class="m-auto"
+      />
     </div>
 
-    <!-- 모집 글이 없을때  -->
+    <!-- 목록이 없을 때 -->
     <div
       v-else-if="filteredPosts?.length === 0"
-      class="flex flex-col justify-center items-center gap-5 flex-1 h-[600px]"
+      class="h-[400px] flex flex-col gap-4 items-center justify-center"
     >
-      <p class="text-center text-primary-4 h3-b">아직 작성한 모집글이 없습니다.</p>
+      <p class="text-center text-primary-4 h3-b">아직 작성한 글이 없습니다.</p>
       <button
-        @click="router.push('/editrecruitpost')"
+        @click="router.push('/EditRecruitPost')"
         class="bg-primary-3 text-white rounded-lg body-large-m py-2 px-6"
       >
-        모집하러 가볼까요?
+        작성하러 가볼까요?
       </button>
     </div>
-    <PostPagination
-      :currentPage="currentPage"
-      :totalPage="totalPage"
-      @change="handleChangePage"
-      class="m-auto"
-    />
   </div>
 </template>
 <style scoped></style>

--- a/src/pages/Mypage/components/MyRequestList.vue
+++ b/src/pages/Mypage/components/MyRequestList.vue
@@ -10,7 +10,8 @@ import { usePagination } from '@/utils/usePagination';
 import { supabase } from '@/config/supabase';
 
 const statusFilterList = ['전체', '수락 완료', '수락 대기중', '모집 마감'];
-
+// queryClient.invalidateQueries({ queryKey: [키 값] })
+// const queryClient = useQueryClient()
 const router = useRouter();
 
 onMounted(async () => {
@@ -37,9 +38,14 @@ const {
   refetch,
   handleChangePage,
   handleUpdateFilter,
-} = usePagination(fetchMyApplyPostsWithPagination, 'filteredApplyPosts', {
-  status: '',
-});
+} = usePagination(
+  fetchMyApplyPostsWithPagination,
+  'filteredApplyPosts',
+  {
+    status: '',
+  },
+  false,
+);
 
 const handleGetStatus = (status) => {
   handleUpdateFilter({ status });
@@ -64,7 +70,7 @@ const subscribeCancelPostApply = async () => {
   <!-- 로딩중일 때 -->
   <LoadingPage v-if="isLoading" class="w-32 h-32" />
 
-  <div v-else class="flex flex-col gap-5 px-4">
+  <div v-else class="flex flex-col gap-5 px-6">
     <!-- 드롭다운 -->
     <div class="max-w-[126px] ml-auto">
       <FilterDropdown
@@ -75,33 +81,41 @@ const subscribeCancelPostApply = async () => {
       />
     </div>
     <!-- 목록이 있을때  -->
-    <div v-if="filteredPosts?.length > 0" class="flex flex-col justify-center gap-5">
-      <!-- 신청 목록 -->
-      <div class="flex flex-wrap items-center gap-y-10 justify-between">
-        <LargePostCard
-          class="cursor-pointer"
-          v-for="(post, index) in filteredPosts"
-          :key="index"
-          v-if="
-            filteredPosts.status === '전체' ||
-            !filteredPosts.status ||
-            filteredPosts.status === '수락 완료'
-          "
-          :post-id="post.id"
-          :project-title="post.title"
-          :skills="post.techStack"
-          :position="post.position"
-          :application-deadline="post.recruit_deadline"
-          :status="post.accepted ? 'success' : post.finished ? 'done' : 'warning'"
-          @click="router.push(`/RecruitPostDetail/${post.post_id}`)"
-        />
+    <div v-if="filteredPosts?.length > 0" class="flex flex-col gap-7">
+      <div class="flex flex-col justify-center gap-6">
+        <!-- 신청 목록 -->
+        <div class="flex flex-wrap items-center gap-7">
+          <LargePostCard
+            class="cursor-pointer"
+            v-for="(post, index) in filteredPosts"
+            :key="index"
+            v-if="
+              filteredPosts.status === '전체' ||
+              !filteredPosts.status ||
+              filteredPosts.status === '수락 완료'
+            "
+            :post-id="post.id"
+            :project-title="post.title"
+            :skills="post.techStack"
+            :position="post.position"
+            :application-deadline="post.recruit_deadline"
+            :status="post.accepted ? 'success' : post.finished ? 'done' : 'warning'"
+            @click="router.push(`/RecruitPostDetail/${post.post_id}`)"
+          />
+        </div>
       </div>
+      <PostPagination
+        :currentPage="currentPage"
+        :totalPage="totalPage"
+        @change="handleChangePage"
+        class="m-auto"
+      />
     </div>
 
     <!-- 목록이 없을 때 -->
     <div
       v-else-if="filteredPosts?.length === 0"
-      class="flex flex-col justify-center items-center gap-5 flex-1 h-[600px]"
+      class="h-[400px] flex flex-col gap-4 items-center justify-center"
     >
       <p class="text-center text-primary-4 h3-b">아직 신청한 글이 없습니다.</p>
       <button
@@ -111,12 +125,6 @@ const subscribeCancelPostApply = async () => {
         신청하러 가볼까요?
       </button>
     </div>
-    <PostPagination
-      :currentPage="currentPage"
-      :totalPage="totalPage"
-      @change="handleChangePage"
-      class="m-auto"
-    />
   </div>
 </template>
 <style scoped></style>

--- a/src/pages/Mypage/components/MyRequestList.vue
+++ b/src/pages/Mypage/components/MyRequestList.vue
@@ -5,9 +5,9 @@ import FilterDropdown from '@/components/FilterDropdown.vue';
 import { useRouter } from 'vue-router';
 import LoadingPage from '@/pages/LoadingPage.vue';
 import PostPagination from '@/pages/PostListPage/components/PostPagination.vue';
-import { getMyApplyPosts } from '@/api/supabase/post';
 import { usePagination } from '@/utils/usePagination';
 import { supabase } from '@/config/supabase';
+import { getMyApplyPosts } from '@/api/supabase/post';
 
 const statusFilterList = ['전체', '수락 완료', '수락 대기중', '모집 마감'];
 // queryClient.invalidateQueries({ queryKey: [키 값] })

--- a/src/pages/PostListPage/PostListPage.vue
+++ b/src/pages/PostListPage/PostListPage.vue
@@ -182,6 +182,7 @@ const handleInitFilter = () => {
     <section v-if="filteredPosts.length > 0" class="grid grid-cols-4 gap-7 mb-12 w-full">
       <PostCard
         v-for="(item, index) in filteredPosts"
+        :user_id="item.author"
         :key="index"
         :id="item.id"
         :userImage="item.profile_img_path"

--- a/src/pages/PostListPage/PostListPage.vue
+++ b/src/pages/PostListPage/PostListPage.vue
@@ -46,8 +46,6 @@ onMounted(async () => {
 
 // 필터링 & 페이지네이션 처리된 게시물 불러오기
 const fetchPostsWithPagination = async () => {
-  console.log(selectedFilter.value.skills);
-
   const params = {
     position: selectedFilter.value.position,
     stacks: selectedFilter.value.skills, // 기술 스택 필터
@@ -99,21 +97,23 @@ const handleSelectSkill = (skill) => {
   handleUpdateFilter({ skills });
 };
 const handleSelectPosition = (position) => {
+  position = position === '전체' ? null : position;
   handleUpdateFilter({ position });
 };
 const handleSelectRecruitArea = (recruitArea) => {
+  recruitArea = recruitArea === '전체' ? null : recruitArea;
   handleUpdateFilter({ recruitArea });
 };
 const handleSelectMeetingMethod = (meetingMethod) => {
+  meetingMethod = meetingMethod === '전체' ? null : meetingMethod;
   handleUpdateFilter({ meetingMethod });
 };
-
 const handleSelectRecruitStatus = (recruitStatus) => {
+  recruitStatus = recruitStatus === '전체' ? null : recruitStatus;
   handleUpdateFilter({ recruitStatus });
 };
 
 const handleInputSearch = (searchResults) => {
-  // handleUpdateFilter({ searchResults });
   searchInput.value = searchResults;
 };
 

--- a/src/pages/PostListPage/PostListPage.vue
+++ b/src/pages/PostListPage/PostListPage.vue
@@ -38,33 +38,34 @@ watch(
   },
   { flush: 'sync' },
 );
-
 onMounted(async () => {
-  fetchPostsWithPagination();
-
   // 사용자 좋아요 업데이트
   await userStore.setUserPostLikes();
+  fetchPostsWithPagination();
 });
 
 // 필터링 & 페이지네이션 처리된 게시물 불러오기
 const fetchPostsWithPagination = async () => {
-  return await getAllPostsWithPagination(
-    {
-      position: selectedFilter.value.position,
-      techStack: selectedFilter.value.skills,
-      recruitArea: selectedFilter.value.recruitArea,
-      recruitType: currentPostType.value === 'project' ? '프로젝트' : '스터디',
-      onOffline: selectedFilter.value.meetingMethod,
-      finished:
-        selectedFilter.value.recruitStatus === '모집중'
-          ? false
-          : selectedFilter.value.recruitStatus === '모집완료'
-          ? true
-          : '',
-      searchResults: selectedFilter.value.searchResults,
-    },
-    currentPage.value,
-  );
+  console.log(selectedFilter.value.skills);
+
+  const params = {
+    position: selectedFilter.value.position,
+    stacks: selectedFilter.value.skills, // 기술 스택 필터
+    recruitArea: selectedFilter.value.recruitArea,
+    recruitType: currentPostType.value === 'project' ? '프로젝트' : '스터디',
+    onOffline: selectedFilter.value.meetingMethod,
+    finished:
+      selectedFilter.value.recruitStatus === '모집중'
+        ? false
+        : selectedFilter.value.recruitStatus === '모집완료'
+        ? true
+        : '',
+    searchResults: selectedFilter.value.searchResults,
+  };
+
+  const response = await getAllPostsWithPagination(params, currentPage.value);
+
+  return response;
 };
 
 const {
@@ -77,11 +78,11 @@ const {
   handleUpdateFilter,
 } = usePagination(fetchPostsWithPagination, 'filteredPosts', {
   skills: [],
-  position: '',
-  recruitArea: '',
-  meetingMethod: '',
-  recruitStatus: '',
-  searchResults: '',
+  position: null,
+  recruitArea: null,
+  meetingMethod: null,
+  recruitStatus: null,
+  searchResults: null,
 });
 
 // 유형별 필터링 후 API 재호출
@@ -95,6 +96,7 @@ const handleSelectSkill = (skill) => {
   } else {
     skills.splice(skillIndex, 1);
   }
+  handleUpdateFilter({ skills });
 };
 const handleSelectPosition = (position) => {
   handleUpdateFilter({ position });
@@ -111,7 +113,8 @@ const handleSelectRecruitStatus = (recruitStatus) => {
 };
 
 const handleInputSearch = (searchResults) => {
-  handleUpdateFilter({ searchResults });
+  // handleUpdateFilter({ searchResults });
+  searchInput.value = searchResults;
 };
 
 //검색에 디바운싱 적용
@@ -120,7 +123,7 @@ watch(searchInput, (newValue) => {
   clearTimeout(debounceTimeout);
   debounceTimeout = setTimeout(() => {
     handleUpdateFilter({ searchResults: newValue });
-  }, 400);
+  }, 1000);
   // });
 });
 
@@ -188,7 +191,7 @@ const handleInitFilter = () => {
         :userImage="item.profile_img_path"
         :userName="item.name"
         :projectTitle="item.title"
-        :skills="item.techStacks"
+        :skills="item.tech_stacks"
         :position="item.positions"
         :applicationDeadline="item.recruit_deadline"
       />

--- a/src/pages/UserPage/components/UserRecruitmentList.vue
+++ b/src/pages/UserPage/components/UserRecruitmentList.vue
@@ -48,9 +48,14 @@ const {
   selectedFilter,
   handleChangePage,
   handleUpdateFilter,
-} = usePagination(fetchUserPostsWithPagination, 'filteredUserPosts', {
-  order: '최신순',
-});
+} = usePagination(
+  fetchUserPostsWithPagination,
+  'filteredUserPosts',
+  {
+    order: '최신순',
+  },
+  false,
+);
 
 const handleSelectOrder = (order) => {
   handleUpdateFilter({ order });
@@ -68,19 +73,29 @@ const handleSelectOrder = (order) => {
       defaultText="정렬 순서"
       @click:select="handleSelectOrder"
     />
+
     <!-- 모집 글이 있을때 -->
-    <div v-if="filteredPosts?.length > 0" class="flex items-center gap-4 ml-1 flex-wrap">
-      <div v-for="post in filteredPosts" :key="post.id" class="cursor-pointer">
-        <PostCard
-          :id="post.id"
-          :user-image="userInfo.profile_img_path"
-          :user-name="userInfo.name"
-          :project-title="post.title"
-          :skills="post.tech_stacks"
-          :position="post.positions"
-          :application-deadline="post.end_date"
-        />
+    <div v-if="filteredPosts?.length > 0" class="flex flex-col gap-7">
+      <div class="flex items-center gap-4 ml-1 flex-wrap">
+        <div v-for="post in filteredPosts" :key="post.id" class="cursor-pointer">
+          <PostCard
+            :user_id="post.author"
+            :id="post.id"
+            :user-image="userInfo.profile_img_path"
+            :user-name="userInfo.name"
+            :project-title="post.title"
+            :skills="post.tech_stacks"
+            :position="post.positions"
+            :application-deadline="post.end_date"
+          />
+        </div>
       </div>
+      <PostPagination
+        :currentPage="currentPage"
+        :totalPage="totalPage"
+        @change="handleChangePage"
+        class="m-auto"
+      />
     </div>
 
     <!-- 모집 글이 없을때  -->
@@ -96,12 +111,6 @@ const handleSelectOrder = (order) => {
         모집하러 가볼까요?
       </button>
     </div>
-    <PostPagination
-      :currentPage="currentPage"
-      :totalPage="totalPage"
-      @change="handleChangePage"
-      class="m-auto"
-    />
   </div>
 </template>
 <style scoped></style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -108,7 +108,6 @@ router.beforeEach(async (to, from, next) => {
   // const isAuthenticated = await getSession();
   // console.log(isAuthenticated);
 
-
   // 온보딩이 완료된 사용자는 접근 차단
   const { useUserStore } = await import('@/stores/user');
   const userStore = useUserStore();

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -20,7 +20,7 @@ export const useUserStore = defineStore('user', () => {
     const userInfo = await getUserInfo();
     if (userInfo === null) return;
     user.value = userInfo;
-    console.log('확인', user.value);
+    // console.log('확인', user.value);
   };
 
   const setUserPostLikes = async () => {

--- a/src/utils/usePagination.js
+++ b/src/utils/usePagination.js
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/vue-query';
 import { computed, ref, watch } from 'vue';
 
-export const usePagination = (fetchData, queryKey, filters = {}) => {
+export const usePagination = (fetchData, queryKey, filters = {}, enableCache = true) => {
   // 현재 페이지, 전체 페이지
   const currentPage = ref(1);
   const totalPage = computed(() => data?.value?.total_page || 1);
@@ -17,8 +17,8 @@ export const usePagination = (fetchData, queryKey, filters = {}) => {
   const { isLoading, data, refetch } = useQuery({
     queryKey: queryKeys,
     queryFn: fetchData,
-    staleTime: 1000 * 60 * 5, // 유통기한
-    gcTime: 1000 * 60 * 5,
+    staleTime: enableCache ? 1000 * 60 * 5 : 0, // 유통기한
+    gcTime: enableCache ? 1000 * 60 * 5 : 0,
     structuralSharing: true, // 변경되지않은 데이터 재사용
     placeholderData: (prev) => prev, // 대기 상태때 표시해줄 데이터
   });
@@ -32,7 +32,6 @@ export const usePagination = (fetchData, queryKey, filters = {}) => {
   // 페이지 전환시
   const handleChangePage = (page) => {
     currentPage.value = page;
-    // refetch();
   };
 
   //  필터링 업데이트 함수
@@ -42,11 +41,11 @@ export const usePagination = (fetchData, queryKey, filters = {}) => {
 
   return {
     isLoading,
-    refetch,
     filteredPosts,
     currentPage,
     totalPage,
     selectedFilter,
+    refetch,
     handleChangePage,
     handleUpdateFilter,
   };

--- a/src/utils/usePagination.js
+++ b/src/utils/usePagination.js
@@ -14,7 +14,7 @@ export const usePagination = (fetchData, queryKey, filters = {}, enableCache = t
 
   // const queryKeys = computed(() => [queryKey, selectedFilter.value, currentPage.value]);
   const { isLoading, data, refetch } = useQuery({
-    queryKey: [queryKey, { ...selectedFilter.value }, currentPage.value],
+    queryKey: [queryKey, selectedFilter.value, currentPage.value],
     queryFn: fetchData,
     staleTime: enableCache ? 1000 * 60 * 5 : 0, // 유통기한
     gcTime: enableCache ? 1000 * 60 * 5 : 0,
@@ -37,7 +37,6 @@ export const usePagination = (fetchData, queryKey, filters = {}, enableCache = t
   //  필터링 업데이트 함수
   const handleUpdateFilter = (newFilter) => {
     selectedFilter.value = { ...selectedFilter.value, ...newFilter };
-    console.log(selectedFilter.value);
   };
 
   return {

--- a/src/utils/usePagination.js
+++ b/src/utils/usePagination.js
@@ -12,10 +12,9 @@ export const usePagination = (fetchData, queryKey, filters = {}, enableCache = t
   // 필터링
   const selectedFilter = ref(filters);
 
-  const queryKeys = computed(() => [queryKey, selectedFilter.value, currentPage.value]);
-
+  // const queryKeys = computed(() => [queryKey, selectedFilter.value, currentPage.value]);
   const { isLoading, data, refetch } = useQuery({
-    queryKey: queryKeys,
+    queryKey: [queryKey, { ...selectedFilter.value }, currentPage.value],
     queryFn: fetchData,
     staleTime: enableCache ? 1000 * 60 * 5 : 0, // 유통기한
     gcTime: enableCache ? 1000 * 60 * 5 : 0,
@@ -32,11 +31,13 @@ export const usePagination = (fetchData, queryKey, filters = {}, enableCache = t
   // 페이지 전환시
   const handleChangePage = (page) => {
     currentPage.value = page;
+    refetch();
   };
 
   //  필터링 업데이트 함수
   const handleUpdateFilter = (newFilter) => {
     selectedFilter.value = { ...selectedFilter.value, ...newFilter };
+    console.log(selectedFilter.value);
   };
 
   return {


### PR DESCRIPTION
## 🪄 변경 사항
###  마이페이지/유저페이지 
- 필터링 제대로 동작하는지 체크
- 게시물 작성, 신청, 북마크를하고 마이페이지에 왔을때 최신화가 바로안되는 문제 해결

### 메인페이지
- 3가지 섹션 조회할 때, 전체 게시글을 조회하는 것이 아닌 페이지네이션 쪽 API로 변경(rpc 함수사용)
- 본인 프로필 클릭 시, 프로필 모달에 “마이페이지로 가기”라는 내용으로 버튼 이름 변경
- 본인 프로필 페이지로 이동할 시, 마이페이지로 이동되도록 수정

### 게시물 목록 페이지
- 목록페이지 게시물 불러오는 API함수 rpc함수로 만들어 네트워크 요청 감축

### 공통 해결 사항
- 유저 프로필 모달을 연결해야 하는 부분들 찾아서 연결
## 💡 반영 브랜치
- resolved #108 
## 🖼️ 결과 화면 (생략 가능)

## 💬 리뷰어에게 전할 말
