### PR TITLE
💄 style : 메인페이지 스와이퍼 위치 이동

### DIFF
--- a/src/pages/MainPage/components/SwipeablePostSection.vue
+++ b/src/pages/MainPage/components/SwipeablePostSection.vue
@@ -36,14 +36,25 @@ watch(() => props.posts, updateSwiper, { deep: true });
 </script>
 
 <template>
-  <article>
-    <div class="flex flex-wrap items-center gap-2.5 mb-6">
-      <h2 class="h1-b text-gray-90">{{ title }}</h2>
-      <StatusBadge :status="badgeStatus" class="px-2.5 py-[3px]">
-        {{ badgeText }}
-      </StatusBadge>
-    </div>
+  <article class="relative">
     <div class="swiper-wrap relative mb-[60px]">
+      <div class="mb-6 flex justify-between items-center">
+        <div class="flex flex-wrap items-center gap-2.5">
+          <h2 class="h1-b text-gray-90">{{ title }}</h2>
+          <StatusBadge :status="badgeStatus" class="px-2.5 py-[3px]">
+            {{ badgeText }}
+          </StatusBadge>
+        </div>
+
+        <div :id="swiperId" class="flex justify-end space-x-2">
+          <button class="scroll-arrow left-arrow">
+            <img :src="ArrowLeft" alt="left" />
+          </button>
+          <button class="scroll-arrow right-arrow">
+            <img :src="ArrowRight" alt="right" />
+          </button>
+        </div>
+      </div>
       <swiper
         :modules="[Navigation]"
         :slides-per-view="4"
@@ -74,14 +85,6 @@ watch(() => props.posts, updateSwiper, { deep: true });
           />
         </swiper-slide>
       </swiper>
-      <div :id="swiperId" class="mt-2 flex justify-end space-x-2">
-        <button class="scroll-arrow left-arrow">
-          <img :src="ArrowLeft" alt="left" />
-        </button>
-        <button class="scroll-arrow right-arrow">
-          <img :src="ArrowRight" alt="right" />
-        </button>
-      </div>
     </div>
   </article>
 </template>


### PR DESCRIPTION
## 🪄 변경 사항
- 메인페이지 스와이퍼 위치 이동했습니다(우측 상단)
## 💡 반영 브랜치
- style-main-swiper-#125
## 🖼️ 결과 화면 (생략 가능)
![image](https://github.com/user-attachments/assets/8ab6839b-b17a-447b-9f4b-a0b82b6d8340)

## 💬 리뷰어에게 전할 말
